### PR TITLE
[APM][Otel] Errors: Add fallback to span id if the parent id is undefined

### DIFF
--- a/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
@@ -27,6 +27,7 @@ import {
   TRACE_ID,
   TRANSACTION_ID,
   ERROR_STACK_TRACE,
+  SPAN_ID,
 } from '../../../../common/es_fields/apm';
 import { environmentQuery } from '../../../../common/utils/environment_query';
 import { ApmDocumentType } from '../../../../common/document_type';
@@ -79,6 +80,7 @@ export async function getErrorSampleDetails({
 
   const optionalFields = asMutableArray([
     TRANSACTION_ID,
+    SPAN_ID,
     AGENT_VERSION,
     PROCESSOR_NAME,
     ERROR_STACK_TRACE,
@@ -129,7 +131,7 @@ export async function getErrorSampleDetails({
 
   const errorFromFields = unflattenKnownApmEventFields(hit.fields, requiredFields);
 
-  const transactionId = errorFromFields.transaction?.id;
+  const transactionId = errorFromFields.transaction?.id ?? errorFromFields.span?.id;
   const traceId = errorFromFields.trace.id;
 
   let transaction: Transaction | undefined;

--- a/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
@@ -159,6 +159,10 @@ export async function getTraceItems({
 
     const waterfallErrorEvent: WaterfallError = {
       ...event,
+      parent: {
+        ...event?.parent,
+        id: event?.parent?.id ?? event?.span?.id,
+      },
       error: {
         ...(event.error ?? {}),
         exception:


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/195731

follows https://github.com/elastic/kibana/pull/195796

## Summary
This PR fixes a bug with error correlations not displayed correctly in the APM waterfall when using Otel native data. In Otel native data `parent.id` is never defined so in this case we need to fallback to `span.id`