### PR TITLE
[APM][Otel] Errors without an error type result in error details page crashing

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -36,7 +36,7 @@ import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plug
 import { useLegacyUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
 import { useApmRouter } from '../../../../hooks/use_apm_router';
-import { FETCH_STATUS, isPending } from '../../../../hooks/use_fetcher';
+import { FETCH_STATUS, isPending, isSuccess } from '../../../../hooks/use_fetcher';
 import { useTraceExplorerEnabledSetting } from '../../../../hooks/use_trace_explorer_enabled_setting';
 import { APIReturnType } from '../../../../services/rest/create_call_apm_api';
 import { TransactionDetailLink } from '../../../shared/links/apm/transaction_detail_link';
@@ -111,8 +111,7 @@ export function ErrorSampleDetails({
   const loadingErrorData = isPending(errorFetchStatus);
   const isLoading = loadingErrorSamplesData || loadingErrorData;
 
-  const isSucceded =
-    errorSamplesFetchStatus === FETCH_STATUS.SUCCESS && errorFetchStatus === FETCH_STATUS.SUCCESS;
+  const isSucceeded = isSuccess(errorSamplesFetchStatus) && isSuccess(errorFetchStatus);
 
   useEffect(() => {
     setSampleActivePage(0);
@@ -137,7 +136,7 @@ export function ErrorSampleDetails({
     });
   }, [error, transaction, uiActions]);
 
-  if (!error && errorSampleIds?.length === 0 && isSucceded) {
+  if (!error && errorSampleIds?.length === 0 && isSucceeded) {
     return (
       <EuiEmptyPrompt
         title={
@@ -160,7 +159,7 @@ export function ErrorSampleDetails({
   const status = error.http?.response?.status_code;
   const environment = error.service.environment;
   const serviceVersion = error.service.version;
-  const isUnhandled = error.error.exception?.[0].handled === false;
+  const isUnhandled = error.error.exception?.[0]?.handled === false;
 
   const traceExplorerLink = router.link('/traces/explorer/waterfall', {
     query: {
@@ -371,7 +370,7 @@ export function ErrorSampleDetailTabContent({
       return isPlaintextException ? (
         <PlaintextStacktrace
           message={exceptions[0].message}
-          type={exceptions[0].type}
+          type={exceptions[0]?.type}
           stacktrace={error?.error.stack_trace}
           codeLanguage={codeLanguage}
         />

--- a/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
@@ -7,7 +7,6 @@
 
 import { rangeQuery, kqlQuery } from '@kbn/observability-plugin/server';
 import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
-import { castArray } from 'lodash';
 import { asMutableArray } from '../../../../common/utils/as_mutable_array';
 import { maybe } from '../../../../common/utils/maybe';
 import {
@@ -155,7 +154,10 @@ export async function getErrorSampleDetails({
       },
       error: {
         ...errorFromFields.error,
-        exception: castArray(source?.error.exception ?? errorFromFields?.error.exception),
+        exception:
+          (source?.error.exception?.length ?? 0) > 1
+            ? source?.error.exception
+            : errorFromFields?.error.exception && [errorFromFields.error.exception],
         log: source?.error?.log,
       },
     },


### PR DESCRIPTION
## Summary

This PR fixes missing exceptions in the error details issue. It happens when an error view is opened for an error without type: 
<img width="1574" alt="image" src="https://github.com/user-attachments/assets/92dd4ff7-2666-476e-b295-7df21df14074">
<img width="1581" alt="image" src="https://github.com/user-attachments/assets/85915a47-1e13-4c72-b323-5e3d9c4ab96d">


## Testing
To simulate missing `exception` field there is an easy way to do this with 2 small changes using `synthtrace` and `simple_trace`: 
- simple_trace.ts
![image](https://github.com/user-attachments/assets/4f90a8d3-bbd4-405d-b303-0023f283cd9e)
- instance.ts
![image](https://github.com/user-attachments/assets/9f624711-3459-40da-8245-431f23233218)
- After that run: 
`node scripts/synthtrace simple_trace.ts`
