### PR TITLE
[APM][Otel] Fix an error with mobile services

### DIFF
--- a/packages/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts
+++ b/packages/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts
@@ -35,7 +35,7 @@ export interface TransactionRaw extends APMBaseDoc {
   trace: { id: string }; // trace is required
   event?: { outcome?: EventOutcome };
   transaction: {
-    duration: { us: number };
+    duration?: { us?: number };
     id: string;
     marks?: {
       // "agent": not defined by APM Server - only sent by RUM agent
@@ -46,12 +46,12 @@ export interface TransactionRaw extends APMBaseDoc {
     name?: string;
     page?: Page; // special property for RUM: shared by error and transaction
     result?: string;
-    sampled: boolean;
+    sampled?: boolean;
     span_count?: {
       started?: number;
       dropped?: number;
     };
-    type: string;
+    type?: string;
     custom?: Record<string, unknown>;
     message?: {
       queue?: { name: string };

--- a/packages/kbn-apm-types/src/es_schemas/ui/transaction.ts
+++ b/packages/kbn-apm-types/src/es_schemas/ui/transaction.ts
@@ -15,7 +15,7 @@ import { Agent } from './fields/agent';
 // and thus it doesn't make sense to treat it as optional
 type InnerTransaction = TransactionRaw['transaction'];
 interface InnerTransactionWithName extends InnerTransaction {
-  name: string;
+  name?: string;
 }
 
 export interface Transaction extends TransactionRaw {

--- a/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
+++ b/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
@@ -22,11 +22,11 @@ export interface WaterfallTransaction {
   event?: { outcome?: EventOutcome };
   parent?: { id?: string };
   processor: { event: 'transaction' };
-  transaction: {
-    duration: { us: number };
+  transaction?: {
+    duration?: { us?: number };
     id: string;
-    name: string;
-    type: string;
+    name?: string;
+    type?: string;
     result?: string;
   };
   faas?: {

--- a/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
@@ -274,12 +274,7 @@ async function getTraceDocsPerPage({
     PROCESSOR_EVENT,
   ] as const);
 
-  const requiredTxFields = asMutableArray([
-    TRANSACTION_ID,
-    TRANSACTION_DURATION,
-    TRANSACTION_NAME,
-    TRANSACTION_TYPE,
-  ] as const);
+  const requiredTxFields = asMutableArray([TRANSACTION_ID] as const);
 
   const requiredSpanFields = asMutableArray([
     SPAN_ID,
@@ -301,6 +296,9 @@ async function getTraceDocsPerPage({
     SPAN_COMPOSITE_SUM,
     SPAN_SYNC,
     CHILD_ID,
+    TRANSACTION_NAME,
+    TRANSACTION_TYPE,
+    TRANSACTION_DURATION,
   ] as const);
 
   const body = {

--- a/x-pack/plugins/observability_solution/apm/server/routes/transactions/get_transaction/index.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/transactions/get_transaction/index.ts
@@ -52,13 +52,16 @@ export async function getTransaction({
     TIMESTAMP_US,
     SERVICE_NAME,
     TRANSACTION_ID,
+  ] as const);
+
+  const optionalFields = asMutableArray([
+    PROCESSOR_NAME,
+    SERVICE_LANGUAGE_NAME,
     TRANSACTION_DURATION,
     TRANSACTION_NAME,
     TRANSACTION_SAMPLED,
     TRANSACTION_TYPE,
   ] as const);
-
-  const optionalFields = asMutableArray([PROCESSOR_NAME, SERVICE_LANGUAGE_NAME] as const);
 
   const resp = await apmEventClient.search('get_transaction', {
     apm: {
@@ -83,7 +86,7 @@ export async function getTransaction({
         },
       },
       fields: [...requiredFields, ...optionalFields],
-      _source: [SPAN_LINKS, TRANSACTION_AGENT_MARKS],
+      _source: [SPAN_LINKS, TRANSACTION_AGENT_MARKS, TRANSACTION_NAME],
     },
   });
 


### PR DESCRIPTION
Closes #196161
## Summary

This PR makes some transaction fields optional because the mobile services don't have them

## Testing 

- open all the mobile traces using: 
`node scripts/synthtrace mobile.ts`

