### PR TITLE
Quick Actions via Context

### DIFF
--- a/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-unified-metrics-grid/src/components/chart/lens_wrapper.tsx
@@ -10,6 +10,7 @@ import React, { useCallback } from 'react';
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { ChartSectionProps } from '@kbn/unified-histogram/types';
+import { PresentationPanelQuickActionContext } from '@kbn/presentation-panel-plugin/public';
 import type { LensProps } from './hooks/use_lens_props';
 import { useLensExtraActions } from './hooks/use_lens_extra_actions';
 import { ChartTitle } from './chart_title';
@@ -103,19 +104,23 @@ export function LensWrapper({
 
   return (
     <div css={chartCss}>
-      <ChartTitle highlight={titleHighlight} title={lensProps.attributes.title} />
-      <EmbeddableComponent
-        {...lensProps}
-        title={lensProps.attributes.title}
-        extraActions={extraActions}
-        abortController={abortController}
-        disabledActions={DEFAULT_DISABLED_ACTIONS}
-        withDefaultActions
-        onBrushEnd={onBrushEnd}
-        onFilter={onFilter}
-        syncTooltips={syncTooltips}
-        syncCursor={syncCursor}
-      />
+      <PresentationPanelQuickActionContext.Provider
+        value={{ view: ['ACTION_METRICS_EXPERIENCE_EXPLORE_IN_DISCOVER_TAB', 'openInspector'] }}
+      >
+        <ChartTitle highlight={titleHighlight} title={lensProps.attributes.title} />
+        <EmbeddableComponent
+          {...lensProps}
+          title={lensProps.attributes.title}
+          extraActions={extraActions}
+          abortController={abortController}
+          disabledActions={DEFAULT_DISABLED_ACTIONS}
+          withDefaultActions
+          onBrushEnd={onBrushEnd}
+          onFilter={onFilter}
+          syncTooltips={syncTooltips}
+          syncCursor={syncCursor}
+        />
+      </PresentationPanelQuickActionContext.Provider>
     </div>
   );
 }

--- a/src/platform/plugins/private/presentation_panel/public/index.ts
+++ b/src/platform/plugins/private/presentation_panel/public/index.ts
@@ -13,6 +13,8 @@ export function plugin() {
   return new PresentationPanelPlugin();
 }
 
+export { PresentationPanelQuickActionContext } from './panel_component/panel_header/presentation_panel_quick_action_context';
+export { DEFAULT_QUICK_ACTION_IDS } from './panel_component/constants';
 export { ACTION_CUSTOMIZE_PANEL } from './panel_actions/customize_panel_action/constants';
 export { ACTION_EDIT_PANEL } from './panel_actions/edit_panel_action/constants';
 export { PresentationPanel } from './panel_component';

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/constants.ts
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/constants.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { PresentationPanelQuickActionIds } from './types';
+
+export const DEFAULT_QUICK_ACTION_IDS: PresentationPanelQuickActionIds = {
+  edit: [
+    'editPanel',
+    'ACTION_CONFIGURE_IN_LENS',
+    'ACTION_CUSTOMIZE_PANEL',
+    'ACTION_OPEN_IN_DISCOVER',
+    'ACTION_VIEW_SAVED_SEARCH',
+    'CONVERT_LEGACY_MARKDOWN',
+  ],
+  view: [
+    'ACTION_SHOW_CONFIG_PANEL',
+    'ACTION_OPEN_IN_DISCOVER',
+    'ACTION_VIEW_SAVED_SEARCH',
+    'openInspector',
+    'togglePanel',
+  ],
+} as const;

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.tsx
@@ -10,7 +10,7 @@
 import { i18n } from '@kbn/i18n';
 import classNames from 'classnames';
 import type { MouseEventHandler, ReactElement } from 'react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { EuiContextMenuPanelDescriptor, IconType } from '@elastic/eui';
 import {
@@ -43,6 +43,8 @@ import {
 } from '../../panel_actions';
 import type { AnyApiAction } from '../../panel_actions/types';
 import type { DefaultPresentationPanelApi, PresentationPanelInternalProps } from '../types';
+import { PresentationPanelQuickActionContext } from './presentation_panel_quick_action_context';
+import { DEFAULT_QUICK_ACTION_IDS } from '../constants';
 
 const getContextMenuAriaLabel = (title?: string, index?: number) => {
   if (title) {
@@ -61,26 +63,6 @@ const getContextMenuAriaLabel = (title?: string, index?: number) => {
     defaultMessage: 'Panel options',
   });
 };
-
-const QUICK_ACTION_IDS = {
-  edit: [
-    'editPanel',
-    'ACTION_CONFIGURE_IN_LENS',
-    'ACTION_CUSTOMIZE_PANEL',
-    'ACTION_OPEN_IN_DISCOVER',
-    'ACTION_VIEW_SAVED_SEARCH',
-    'CONVERT_LEGACY_MARKDOWN',
-  ],
-  view: [
-    'ACTION_SHOW_CONFIG_PANEL',
-    'ACTION_OPEN_IN_DISCOVER',
-    'ACTION_VIEW_SAVED_SEARCH',
-    'openInspector',
-    'togglePanel',
-    // equivalent to ACTION_OPEN_IN_DISCOVER but exclusive to Metrics Experience in Discover
-    'ACTION_METRICS_EXPERIENCE_EXPLORE_IN_DISCOVER_TAB',
-  ],
-} as const;
 
 const ALLOWED_NOTIFICATIONS = ['ACTION_FILTERS_NOTIFICATION'] as const;
 
@@ -135,22 +117,32 @@ export const PresentationPanelHoverActions = ({
 
   const { euiTheme } = useEuiTheme();
 
-  const [title, description, hidePanelTitle, hasLockedHoverActions, parentHideTitle] =
-    useBatchedOptionalPublishingSubjects(
-      api?.title$,
-      api?.description$,
-      api?.hideTitle$,
-      api?.hasLockedHoverActions$,
-      (api?.parentApi as Partial<PublishesTitle>)?.hideTitle$
-    );
+  const [
+    title,
+    description,
+    hidePanelTitle,
+    hasLockedHoverActions,
+    parentHideTitle,
+    disabledActionIds,
+  ] = useBatchedOptionalPublishingSubjects(
+    api?.title$,
+    api?.description$,
+    api?.hideTitle$,
+    api?.hasLockedHoverActions$,
+    (api?.parentApi as Partial<PublishesTitle>)?.hideTitle$,
+    api?.disabledActionIds$
+  );
 
   const hideTitle = hidePanelTitle || parentHideTitle;
   const showDescription = description && (!title || hideTitle);
 
-  const quickActionIds = useMemo(
-    () => QUICK_ACTION_IDS[viewMode === 'edit' ? 'edit' : 'view'],
-    [viewMode]
-  );
+  const contextActionIds = useContext(PresentationPanelQuickActionContext);
+  const quickActionIds = useMemo(() => {
+    const actionMode = viewMode === 'edit' ? 'edit' : 'view';
+    return (contextActionIds?.[actionMode] ?? DEFAULT_QUICK_ACTION_IDS[actionMode])?.filter(
+      (actionId) => actionId && (disabledActionIds ?? [])?.indexOf(actionId) === -1
+    );
+  }, [viewMode, contextActionIds, disabledActionIds]);
 
   const onClose = useCallback(() => {
     setIsContextMenuOpen(false);
@@ -266,10 +258,9 @@ export const PresentationPanelHoverActions = ({
       })()) as AnyApiAction[];
       if (canceled) return;
 
-      const disabledActions = api.disabledActionIds$?.value;
-      if (disabledActions) {
+      if (disabledActionIds) {
         compatibleActions = compatibleActions.filter(
-          (action) => disabledActions.indexOf(action.id) === -1
+          (action) => disabledActionIds.indexOf(action.id) === -1
         );
       }
 
@@ -303,7 +294,16 @@ export const PresentationPanelHoverActions = ({
     return () => {
       canceled = true;
     };
-  }, [actionPredicate, api, getActions, isContextMenuOpen, onClose, viewMode, quickActionIds]);
+  }, [
+    actionPredicate,
+    api,
+    getActions,
+    isContextMenuOpen,
+    onClose,
+    viewMode,
+    quickActionIds,
+    disabledActionIds,
+  ]);
 
   const quickActionElements = useMemo(() => {
     if (!api || quickActions.length < 1) return [];

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_quick_action_context.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_quick_action_context.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { createContext } from 'react';
+import type { PresentationPanelQuickActionIds } from '../types';
+
+export const PresentationPanelQuickActionContext = createContext<
+  PresentationPanelQuickActionIds | undefined
+>(undefined);

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/types.ts
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/types.ts
@@ -17,6 +17,7 @@ import type {
   PublishesDescription,
   PublishesTitle,
   CanOverrideHoverActions,
+  ViewMode,
 } from '@kbn/presentation-publishing';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { MaybePromise } from '@kbn/utility-types';
@@ -88,4 +89,16 @@ export type PresentationPanelProps<
   PropsType extends {} = {}
 > = Omit<PresentationPanelInternalProps<ApiType, PropsType>, 'Component'> & {
   Component: MaybePromise<PanelCompatibleComponent<ApiType, PropsType> | null>;
+};
+
+export type QuickActionIds = [string?, string?, string?, string?, string?, string?];
+
+type ActionViewMode = Extract<ViewMode, 'view' | 'edit'>;
+
+/**
+ * Limited sets of 6 action ids that will be promoted to quick actions on the panel header that appear on hover.
+ * Actions in this list only appear if they are deemed compatible. Use PresentationPanelQuickActionContext to customize.
+ */
+export type PresentationPanelQuickActionIds = {
+  [key in ActionViewMode]?: QuickActionIds;
 };


### PR DESCRIPTION
## Summary
Improvements the presentation team code changes in https://github.com/elastic/kibana/pull/245035 by adding a context that can be used to change the quick action IDs and making the `disabledActionIds` work properly with quick actions also.