### PR TITLE
Convert feature duplication evals to `@kbn/evals` evaluator format

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/significant_events/feature_duplication/features_duplication.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/significant_events/feature_duplication/features_duplication.spec.ts
@@ -20,7 +20,7 @@ import {
   featureDuplicationEvaluator,
   createSemanticUniquenessEvaluator,
   createIdConsistencyEvaluator,
-} from '../../../src/evaluators/feature_duplication_evaluators';
+} from '../../../src/evaluators/feature_duplication';
 
 evaluate.describe('Streams features duplication (harness)', () => {
   const from = kbnDatemath.parse('now-10m')!;

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_prompt.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPrompt } from '@kbn/inference-common';
+import { z } from '@kbn/zod/v4';
+import systemPromptText from './id_consistency_system_prompt.text';
+import userPromptText from './id_consistency_user_prompt.text';
+
+const ID_CONSISTENCY_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    collision_groups: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'The feature id that is a collision',
+          },
+          reason: {
+            type: 'string',
+            description:
+              'One sentence explaining why the variants conflict (e.g. "variant A describes X while variant B describes Y")',
+          },
+        },
+        required: ['id', 'reason'],
+      },
+      description:
+        'Id groups you judge as INCONSISTENT (genuine collisions). Omit groups where variants clearly refer to the same underlying concept, even if wording differs.',
+    },
+    explanation: {
+      type: 'string',
+      description:
+        'Brief summary: note what drives collisions (overly generic ids, type confusion, unstable naming, etc.)',
+    },
+  },
+  required: ['collision_groups', 'explanation'],
+} as const;
+
+export const IdConsistencyPrompt = createPrompt({
+  name: 'id_consistency_analysis',
+  description: 'Evaluate id consistency of extracted features across runs',
+  input: z.object({
+    stream_name: z.string(),
+    context: z.string(),
+    id_groups: z.string(),
+  }),
+})
+  .version({
+    system: {
+      mustache: {
+        template: systemPromptText,
+      },
+    },
+    template: {
+      mustache: {
+        template: userPromptText,
+      },
+    },
+    toolChoice: {
+      function: 'evaluate',
+    },
+    tools: {
+      evaluate: {
+        description: 'Return id consistency evaluation',
+        schema: ID_CONSISTENCY_OUTPUT_SCHEMA,
+      },
+    },
+  } as const)
+  .get();

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_system_prompt.text
@@ -1,0 +1,13 @@
+You are an automated quality-assurance LLM evaluating feature extraction from log streams.
+
+You are given groups of features that share the same id but were produced with different content across multiple runs on the SAME stream.
+Features with the same id should always represent the same underlying real-world concept. An id collision — the same id used for genuinely different concepts — is a bug.
+
+Definitions:
+- "Consistent": all variants in the group clearly refer to the same underlying concept, even if minor wording or property details differ.
+- "Collision" (inconsistent): the same id is used for different concepts in different runs.
+
+Method:
+- For each id group, decide: consistent or collision.
+- Only include groups in collision_groups that are genuine collisions.
+- M (total ambiguous groups) and trivially_consistent_ids are provided as context; you do not need to report them.

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_user_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_user_prompt.text
@@ -1,0 +1,11 @@
+Evaluate the following feature id groups for consistency:
+
+**Stream name**: {{{stream_name}}}
+
+**Context**:
+{{{context}}}
+
+**Id groups**:
+{{{id_groups}}}
+
+Please evaluate each id group and call the `evaluate` tool with your findings.

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/index.ts
@@ -8,75 +8,9 @@
 import { hasSameFingerprint, type BaseFeature } from '@kbn/streams-schema';
 import { uniqBy, uniqWith } from 'lodash';
 import type { BoundInferenceClient } from '@kbn/inference-common';
-
-const SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA = {
-  type: 'object',
-  properties: {
-    k: {
-      type: 'number',
-      description:
-        'Number of semantic clusters you formed — each cluster = one unique real-world concept. K is always <= N (the total number of unique-by-id features provided in the input). (integer)',
-    },
-    explanation: {
-      type: 'string',
-      description:
-        'Your reasoning: list confirmed duplicate clusters with their one-sentence identity statements, and briefly note what drives duplication (id naming instability, overly generic ids, etc.)',
-    },
-    duplicate_clusters: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          ids: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Feature ids that form the duplicate cluster',
-          },
-          identity_statement: {
-            type: 'string',
-            description:
-              'One sentence naming the single real-world component or process all members refer to',
-          },
-        },
-        required: ['ids', 'identity_statement'],
-      },
-      description: 'Up to 5 of the largest confirmed duplicate clusters',
-    },
-  },
-  required: ['k', 'explanation', 'duplicate_clusters'],
-} as const;
-
-const ID_CONSISTENCY_OUTPUT_SCHEMA = {
-  type: 'object',
-  properties: {
-    collision_groups: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            description: 'The feature id that is a collision',
-          },
-          reason: {
-            type: 'string',
-            description:
-              'One sentence explaining why the variants conflict (e.g. "variant A describes X while variant B describes Y")',
-          },
-        },
-        required: ['id', 'reason'],
-      },
-      description:
-        'Id groups you judge as INCONSISTENT (genuine collisions). Omit groups where variants clearly refer to the same underlying concept, even if wording differs.',
-    },
-    explanation: {
-      type: 'string',
-      description:
-        'Brief summary: note what drives collisions (overly generic ids, type confusion, unstable naming, etc.)',
-    },
-  },
-  required: ['collision_groups', 'explanation'],
-} as const;
+import { executeUntilValid } from '@kbn/inference-prompt-utils';
+import { SemanticUniquenessPrompt } from './semantic_uniqueness_prompt';
+import { IdConsistencyPrompt } from './id_consistency_prompt';
 
 /**
  * Checks that all unique-by-id features are semantically distinct.
@@ -121,42 +55,29 @@ export const createSemanticUniquenessEvaluator = ({
         `${a.type}:${a.subtype ?? ''}:${a.id}`.localeCompare(`${b.type}:${b.subtype ?? ''}:${b.id}`)
       );
 
-    const result = await inferenceClient.output({
-      id: 'semantic_uniqueness_analysis',
-      system: `You are an automated quality-assurance LLM evaluating feature extraction from log streams.
-
-Your task: given a list of features already de-duplicated by id (one representative per unique id), determine whether all unique ids are truly semantically distinct, or whether some are SEMANTIC DUPLICATES — features that refer to the exact same underlying real-world component or fact, even if their ids, titles, or descriptions differ slightly.
-
-Definitions:
-- Only compare features within the same category: type + subtype must match for two features to be considered duplicates.
-- If ambiguous, treat as NOT duplicates.
-- Same technology family ≠ duplicates. Only truly interchangeable features are duplicates.
-- Two features are duplicates only if an operator would consider them interchangeable: knowing one tells you everything knowing the other would.
-
-Burden of proof for each cluster:
-- You must be able to state in one sentence what single real-world thing all members refer to.
-- A valid identity statement names a specific component or process, not a category or domain.
-- If you cannot write the one-sentence identity, the features are NOT duplicates.
-
-Method:
-1. Read the full list of unique features.
-2. Apply the burden-of-proof test before finalising each cluster.
-3. Return K = the number of semantic clusters you formed. K must be <= N (provided in the input as unique_by_id).`,
-      input: JSON.stringify({
+    const response = await executeUntilValid({
+      prompt: SemanticUniquenessPrompt,
+      inferenceClient,
+      input: {
         stream_name: input?.stream_name,
-        totals: {
+        totals: JSON.stringify({
           runs: runs.length,
           total_features: allFeatures.length,
           unique_by_id: uniqueById,
           unique_by_fingerprint: uniqueByFingerprint,
-        },
-        unique_features_by_id: compactUniqueFeatures,
-      }),
-      schema: SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA,
-      retry: { onValidationError: 3 },
+        }),
+        unique_features_by_id: JSON.stringify(compactUniqueFeatures),
+      },
+      finalToolChoice: { function: 'analyze' as const },
+      maxRetries: 3,
+      toolCallbacks: {
+        analyze: async (toolCall) => ({
+          response: toolCall.function.arguments,
+        }),
+      },
     });
 
-    const { k, explanation, duplicate_clusters } = result.output;
+    const { k, explanation, duplicate_clusters } = response.toolCalls[0].function.arguments;
     const score = uniqueById > 0 ? k / uniqueById : 1;
 
     return {
@@ -248,35 +169,28 @@ export const createIdConsistencyEvaluator = ({
       })),
     }));
 
-    const result = await inferenceClient.output({
-      id: 'id_consistency_analysis',
-      system: `You are an automated quality-assurance LLM evaluating feature extraction from log streams.
-
-You are given groups of features that share the same id but were produced with different content across multiple runs on the SAME stream.
-Features with the same id should always represent the same underlying real-world concept. An id collision — the same id used for genuinely different concepts — is a bug.
-
-Definitions:
-- "Consistent": all variants in the group clearly refer to the same underlying concept, even if minor wording or property details differ.
-- "Collision" (inconsistent): the same id is used for different concepts in different runs.
-
-Method:
-- For each id group, decide: consistent or collision.
-- Only include groups in collision_groups that are genuine collisions.
-- M (total ambiguous groups) and trivially_consistent_ids are provided as context; you do not need to report them.`,
-      input: JSON.stringify({
+    const response = await executeUntilValid({
+      prompt: IdConsistencyPrompt,
+      inferenceClient,
+      input: {
         stream_name: input?.stream_name,
-        context: {
+        context: JSON.stringify({
           total_multi_occurrence_ids: totalMultiOccurrence,
           trivially_consistent_ids: triviallyConsistent.length,
           ambiguous_ids_sent_to_llm: ambiguous.length,
-        },
-        id_groups: idGroups,
-      }),
-      schema: ID_CONSISTENCY_OUTPUT_SCHEMA,
-      retry: { onValidationError: 3 },
+        }),
+        id_groups: JSON.stringify(idGroups),
+      },
+      finalToolChoice: { function: 'evaluate' as const },
+      maxRetries: 3,
+      toolCallbacks: {
+        evaluate: async (toolCall) => ({
+          response: toolCall.function.arguments,
+        }),
+      },
     });
 
-    const { collision_groups, explanation } = result.output;
+    const { collision_groups, explanation } = response.toolCalls[0].function.arguments;
 
     const llmConsistent = ambiguous.length - collision_groups.length;
     const finalScore = (triviallyConsistent.length + llmConsistent) / totalMultiOccurrence;

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_prompt.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPrompt } from '@kbn/inference-common';
+import { z } from '@kbn/zod/v4';
+import systemPromptText from './semantic_uniqueness_system_prompt.text';
+import userPromptText from './semantic_uniqueness_user_prompt.text';
+
+const SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    k: {
+      type: 'number',
+      description:
+        'Number of semantic clusters you formed — each cluster = one unique real-world concept. K is always <= N (the total number of unique-by-id features provided in the input). (integer)',
+    },
+    explanation: {
+      type: 'string',
+      description:
+        'Your reasoning: list confirmed duplicate clusters with their one-sentence identity statements, and briefly note what drives duplication (id naming instability, overly generic ids, etc.)',
+    },
+    duplicate_clusters: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Feature ids that form the duplicate cluster',
+          },
+          identity_statement: {
+            type: 'string',
+            description:
+              'One sentence naming the single real-world component or process all members refer to',
+          },
+        },
+        required: ['ids', 'identity_statement'],
+      },
+      description: 'Up to 5 of the largest confirmed duplicate clusters',
+    },
+  },
+  required: ['k', 'explanation', 'duplicate_clusters'],
+} as const;
+
+export const SemanticUniquenessPrompt = createPrompt({
+  name: 'semantic_uniqueness_analysis',
+  description: 'Evaluate semantic uniqueness of extracted features',
+  input: z.object({
+    stream_name: z.string(),
+    totals: z.string(),
+    unique_features_by_id: z.string(),
+  }),
+})
+  .version({
+    system: {
+      mustache: {
+        template: systemPromptText,
+      },
+    },
+    template: {
+      mustache: {
+        template: userPromptText,
+      },
+    },
+    toolChoice: {
+      function: 'analyze',
+    },
+    tools: {
+      analyze: {
+        description: 'Return semantic uniqueness analysis',
+        schema: SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA,
+      },
+    },
+  } as const)
+  .get();

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_system_prompt.text
@@ -1,0 +1,19 @@
+You are an automated quality-assurance LLM evaluating feature extraction from log streams.
+
+Your task: given a list of features already de-duplicated by id (one representative per unique id), determine whether all unique ids are truly semantically distinct, or whether some are SEMANTIC DUPLICATES — features that refer to the exact same underlying real-world component or fact, even if their ids, titles, or descriptions differ slightly.
+
+Definitions:
+- Only compare features within the same category: type + subtype must match for two features to be considered duplicates.
+- If ambiguous, treat as NOT duplicates.
+- Same technology family ≠ duplicates. Only truly interchangeable features are duplicates.
+- Two features are duplicates only if an operator would consider them interchangeable: knowing one tells you everything knowing the other would.
+
+Burden of proof for each cluster:
+- You must be able to state in one sentence what single real-world thing all members refer to.
+- A valid identity statement names a specific component or process, not a category or domain.
+- If you cannot write the one-sentence identity, the features are NOT duplicates.
+
+Method:
+1. Read the full list of unique features.
+2. Apply the burden-of-proof test before finalising each cluster.
+3. Return K = the number of semantic clusters you formed. K must be <= N (provided in the input as unique_by_id).

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_user_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_user_prompt.text
@@ -1,0 +1,11 @@
+Evaluate the following feature set for semantic uniqueness:
+
+**Stream name**: {{{stream_name}}}
+
+**Totals**:
+{{{totals}}}
+
+**Unique features by id**:
+{{{unique_features_by_id}}}
+
+Please analyze the features and call the `analyze` tool with your findings.

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "@kbn/ambient-common-types"]
   },
   "include": ["**/*.ts"],
   "exclude": ["target/**/*"],
@@ -24,6 +24,8 @@
     "@kbn/core",
     "@kbn/dissect-heuristics",
     "@kbn/inference-common",
+    "@kbn/inference-prompt-utils",
+    "@kbn/zod",
     "@kbn/es-snapshot-loader",
     "@kbn/es-errors"
   ]


### PR DESCRIPTION
## Summary

Closes #255869

Converts the two LLM evaluators (`createSemanticUniquenessEvaluator` and `createIdConsistencyEvaluator`) in `kbn-evals-suite-streams` from using `inferenceClient.output()` with inline prompts to the `createPrompt` + `executeUntilValid` pattern used by `@kbn/evals`.

## Changes

- **Extracted system prompts** into `.text` mustache template files (one system + one user template per evaluator)
- **Created `createPrompt` definitions** with Zod input schemas and tool definitions preserving the original JSON schemas
- **Replaced `inferenceClient.output()`** calls with `executeUntilValid` in both LLM evaluators
- **Reorganized into directory module**: `feature_duplication_evaluators.ts` → `feature_duplication/index.ts` with dedicated prompt files
- **Added dependencies**: `@kbn/inference-prompt-utils`, `@kbn/zod`, and `@kbn/ambient-common-types` to `tsconfig.json`
- **Updated import path** in spec file to point to new directory module

### What stays the same
- The CODE evaluator (`featureDuplicationEvaluator`) is untouched
- All evaluator names, signatures, and return shapes are preserved
- Score calculation logic is identical
- Spec file works without structural changes (only import path updated)

### File structure
```
src/evaluators/feature_duplication/
├── index.ts                              (evaluator factories + CODE evaluator)
├── semantic_uniqueness_prompt.ts          (createPrompt definition)
├── semantic_uniqueness_system_prompt.text (system prompt template)
├── semantic_uniqueness_user_prompt.text   (user prompt template)
├── id_consistency_prompt.ts              (createPrompt definition)
├── id_consistency_system_prompt.text      (system prompt template)
└── id_consistency_user_prompt.text        (user prompt template)
```

## Test plan
- [x] `yarn test:type_check --project x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json` passes
- [x] `node scripts/eslint x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/` passes
- [x] `node scripts/check_changes.ts` passes
- [ ] Run the feature duplication eval suite end-to-end to verify evaluator behavior is preserved


Made with [Cursor](https://cursor.com)