### PR TITLE
refactor(evals): convert feature duplication evaluators to createPrompt pattern

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/significant_events/feature_duplication/features_duplication.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/significant_events/feature_duplication/features_duplication.spec.ts
@@ -20,7 +20,7 @@ import {
   featureDuplicationEvaluator,
   createSemanticUniquenessEvaluator,
   createIdConsistencyEvaluator,
-} from '../../../src/evaluators/feature_duplication_evaluators';
+} from '../../../src/evaluators/feature_duplication';
 
 evaluate.describe('Streams features duplication (harness)', () => {
   const from = kbnDatemath.parse('now-10m')!;

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_prompt.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPrompt } from '@kbn/inference-common';
+import { z } from '@kbn/zod/v4';
+import systemPromptText from './id_consistency_system_prompt.text';
+import userPromptText from './id_consistency_user_prompt.text';
+
+const ID_CONSISTENCY_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    collision_groups: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'The feature id that is a collision',
+          },
+          reason: {
+            type: 'string',
+            description:
+              'One sentence explaining why the variants conflict (e.g. "variant A describes X while variant B describes Y")',
+          },
+        },
+        required: ['id', 'reason'],
+      },
+      description:
+        'Id groups you judge as INCONSISTENT (genuine collisions). Omit groups where variants clearly refer to the same underlying concept, even if wording differs.',
+    },
+    explanation: {
+      type: 'string',
+      description:
+        'Brief summary: note what drives collisions (overly generic ids, type confusion, unstable naming, etc.)',
+    },
+  },
+  required: ['collision_groups', 'explanation'],
+} as const;
+
+export const IdConsistencyPrompt = createPrompt({
+  name: 'id_consistency_analysis',
+  description: 'Evaluate id consistency of extracted features across runs',
+  input: z.object({
+    stream_name: z.string(),
+    context: z.string(),
+    id_groups: z.string(),
+  }),
+})
+  .version({
+    system: {
+      mustache: {
+        template: systemPromptText,
+      },
+    },
+    template: {
+      mustache: {
+        template: userPromptText,
+      },
+    },
+    toolChoice: {
+      function: 'evaluate',
+    },
+    tools: {
+      evaluate: {
+        description: 'Return id consistency evaluation',
+        schema: ID_CONSISTENCY_OUTPUT_SCHEMA,
+      },
+    },
+  } as const)
+  .get();

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_system_prompt.text
@@ -1,0 +1,13 @@
+You are an automated quality-assurance LLM evaluating feature extraction from log streams.
+
+You are given groups of features that share the same id but were produced with different content across multiple runs on the SAME stream.
+Features with the same id should always represent the same underlying real-world concept. An id collision — the same id used for genuinely different concepts — is a bug.
+
+Definitions:
+- "Consistent": all variants in the group clearly refer to the same underlying concept, even if minor wording or property details differ.
+- "Collision" (inconsistent): the same id is used for different concepts in different runs.
+
+Method:
+- For each id group, decide: consistent or collision.
+- Only include groups in collision_groups that are genuine collisions.
+- M (total ambiguous groups) and trivially_consistent_ids are provided as context; you do not need to report them.

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_user_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/id_consistency_user_prompt.text
@@ -1,0 +1,11 @@
+Evaluate the following feature id groups for consistency:
+
+**Stream name**: {{{stream_name}}}
+
+**Context**:
+{{{context}}}
+
+**Id groups**:
+{{{id_groups}}}
+
+Please evaluate each id group and call the `evaluate` tool with your findings.

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/index.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/index.ts
@@ -8,75 +8,9 @@
 import { hasSameFingerprint, type BaseFeature } from '@kbn/streams-schema';
 import { uniqBy, uniqWith } from 'lodash';
 import type { BoundInferenceClient } from '@kbn/inference-common';
-
-const SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA = {
-  type: 'object',
-  properties: {
-    k: {
-      type: 'number',
-      description:
-        'Number of semantic clusters you formed — each cluster = one unique real-world concept. K is always <= N (the total number of unique-by-id features provided in the input). (integer)',
-    },
-    explanation: {
-      type: 'string',
-      description:
-        'Your reasoning: list confirmed duplicate clusters with their one-sentence identity statements, and briefly note what drives duplication (id naming instability, overly generic ids, etc.)',
-    },
-    duplicate_clusters: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          ids: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Feature ids that form the duplicate cluster',
-          },
-          identity_statement: {
-            type: 'string',
-            description:
-              'One sentence naming the single real-world component or process all members refer to',
-          },
-        },
-        required: ['ids', 'identity_statement'],
-      },
-      description: 'Up to 5 of the largest confirmed duplicate clusters',
-    },
-  },
-  required: ['k', 'explanation', 'duplicate_clusters'],
-} as const;
-
-const ID_CONSISTENCY_OUTPUT_SCHEMA = {
-  type: 'object',
-  properties: {
-    collision_groups: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            description: 'The feature id that is a collision',
-          },
-          reason: {
-            type: 'string',
-            description:
-              'One sentence explaining why the variants conflict (e.g. "variant A describes X while variant B describes Y")',
-          },
-        },
-        required: ['id', 'reason'],
-      },
-      description:
-        'Id groups you judge as INCONSISTENT (genuine collisions). Omit groups where variants clearly refer to the same underlying concept, even if wording differs.',
-    },
-    explanation: {
-      type: 'string',
-      description:
-        'Brief summary: note what drives collisions (overly generic ids, type confusion, unstable naming, etc.)',
-    },
-  },
-  required: ['collision_groups', 'explanation'],
-} as const;
+import { executeUntilValid } from '@kbn/inference-prompt-utils';
+import { SemanticUniquenessPrompt } from './semantic_uniqueness_prompt';
+import { IdConsistencyPrompt } from './id_consistency_prompt';
 
 /**
  * Checks that all unique-by-id features are semantically distinct.
@@ -121,42 +55,29 @@ export const createSemanticUniquenessEvaluator = ({
         `${a.type}:${a.subtype ?? ''}:${a.id}`.localeCompare(`${b.type}:${b.subtype ?? ''}:${b.id}`)
       );
 
-    const result = await inferenceClient.output({
-      id: 'semantic_uniqueness_analysis',
-      system: `You are an automated quality-assurance LLM evaluating feature extraction from log streams.
-
-Your task: given a list of features already de-duplicated by id (one representative per unique id), determine whether all unique ids are truly semantically distinct, or whether some are SEMANTIC DUPLICATES — features that refer to the exact same underlying real-world component or fact, even if their ids, titles, or descriptions differ slightly.
-
-Definitions:
-- Only compare features within the same category: type + subtype must match for two features to be considered duplicates.
-- If ambiguous, treat as NOT duplicates.
-- Same technology family ≠ duplicates. Only truly interchangeable features are duplicates.
-- Two features are duplicates only if an operator would consider them interchangeable: knowing one tells you everything knowing the other would.
-
-Burden of proof for each cluster:
-- You must be able to state in one sentence what single real-world thing all members refer to.
-- A valid identity statement names a specific component or process, not a category or domain.
-- If you cannot write the one-sentence identity, the features are NOT duplicates.
-
-Method:
-1. Read the full list of unique features.
-2. Apply the burden-of-proof test before finalising each cluster.
-3. Return K = the number of semantic clusters you formed. K must be <= N (provided in the input as unique_by_id).`,
-      input: JSON.stringify({
+    const response = await executeUntilValid({
+      prompt: SemanticUniquenessPrompt,
+      inferenceClient,
+      input: {
         stream_name: input?.stream_name,
-        totals: {
+        totals: JSON.stringify({
           runs: runs.length,
           total_features: allFeatures.length,
           unique_by_id: uniqueById,
           unique_by_fingerprint: uniqueByFingerprint,
-        },
-        unique_features_by_id: compactUniqueFeatures,
-      }),
-      schema: SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA,
-      retry: { onValidationError: 3 },
+        }),
+        unique_features_by_id: JSON.stringify(compactUniqueFeatures),
+      },
+      finalToolChoice: { function: 'analyze' as const },
+      maxRetries: 3,
+      toolCallbacks: {
+        analyze: async (toolCall) => ({
+          response: toolCall.function.arguments,
+        }),
+      },
     });
 
-    const { k, explanation, duplicate_clusters } = result.output;
+    const { k, explanation, duplicate_clusters } = response.toolCalls[0].function.arguments;
     const score = uniqueById > 0 ? k / uniqueById : 1;
 
     return {
@@ -248,35 +169,28 @@ export const createIdConsistencyEvaluator = ({
       })),
     }));
 
-    const result = await inferenceClient.output({
-      id: 'id_consistency_analysis',
-      system: `You are an automated quality-assurance LLM evaluating feature extraction from log streams.
-
-You are given groups of features that share the same id but were produced with different content across multiple runs on the SAME stream.
-Features with the same id should always represent the same underlying real-world concept. An id collision — the same id used for genuinely different concepts — is a bug.
-
-Definitions:
-- "Consistent": all variants in the group clearly refer to the same underlying concept, even if minor wording or property details differ.
-- "Collision" (inconsistent): the same id is used for different concepts in different runs.
-
-Method:
-- For each id group, decide: consistent or collision.
-- Only include groups in collision_groups that are genuine collisions.
-- M (total ambiguous groups) and trivially_consistent_ids are provided as context; you do not need to report them.`,
-      input: JSON.stringify({
+    const response = await executeUntilValid({
+      prompt: IdConsistencyPrompt,
+      inferenceClient,
+      input: {
         stream_name: input?.stream_name,
-        context: {
+        context: JSON.stringify({
           total_multi_occurrence_ids: totalMultiOccurrence,
           trivially_consistent_ids: triviallyConsistent.length,
           ambiguous_ids_sent_to_llm: ambiguous.length,
-        },
-        id_groups: idGroups,
-      }),
-      schema: ID_CONSISTENCY_OUTPUT_SCHEMA,
-      retry: { onValidationError: 3 },
+        }),
+        id_groups: JSON.stringify(idGroups),
+      },
+      finalToolChoice: { function: 'evaluate' as const },
+      maxRetries: 3,
+      toolCallbacks: {
+        evaluate: async (toolCall) => ({
+          response: toolCall.function.arguments,
+        }),
+      },
     });
 
-    const { collision_groups, explanation } = result.output;
+    const { collision_groups, explanation } = response.toolCalls[0].function.arguments;
 
     const llmConsistent = ambiguous.length - collision_groups.length;
     const finalScore = (triviallyConsistent.length + llmConsistent) / totalMultiOccurrence;

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_prompt.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_prompt.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createPrompt } from '@kbn/inference-common';
+import { z } from '@kbn/zod/v4';
+import systemPromptText from './semantic_uniqueness_system_prompt.text';
+import userPromptText from './semantic_uniqueness_user_prompt.text';
+
+const SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    k: {
+      type: 'number',
+      description:
+        'Number of semantic clusters you formed — each cluster = one unique real-world concept. K is always <= N (the total number of unique-by-id features provided in the input). (integer)',
+    },
+    explanation: {
+      type: 'string',
+      description:
+        'Your reasoning: list confirmed duplicate clusters with their one-sentence identity statements, and briefly note what drives duplication (id naming instability, overly generic ids, etc.)',
+    },
+    duplicate_clusters: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Feature ids that form the duplicate cluster',
+          },
+          identity_statement: {
+            type: 'string',
+            description:
+              'One sentence naming the single real-world component or process all members refer to',
+          },
+        },
+        required: ['ids', 'identity_statement'],
+      },
+      description: 'Up to 5 of the largest confirmed duplicate clusters',
+    },
+  },
+  required: ['k', 'explanation', 'duplicate_clusters'],
+} as const;
+
+export const SemanticUniquenessPrompt = createPrompt({
+  name: 'semantic_uniqueness_analysis',
+  description: 'Evaluate semantic uniqueness of extracted features',
+  input: z.object({
+    stream_name: z.string(),
+    totals: z.string(),
+    unique_features_by_id: z.string(),
+  }),
+})
+  .version({
+    system: {
+      mustache: {
+        template: systemPromptText,
+      },
+    },
+    template: {
+      mustache: {
+        template: userPromptText,
+      },
+    },
+    toolChoice: {
+      function: 'analyze',
+    },
+    tools: {
+      analyze: {
+        description: 'Return semantic uniqueness analysis',
+        schema: SEMANTIC_UNIQUENESS_OUTPUT_SCHEMA,
+      },
+    },
+  } as const)
+  .get();

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_system_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_system_prompt.text
@@ -1,0 +1,19 @@
+You are an automated quality-assurance LLM evaluating feature extraction from log streams.
+
+Your task: given a list of features already de-duplicated by id (one representative per unique id), determine whether all unique ids are truly semantically distinct, or whether some are SEMANTIC DUPLICATES — features that refer to the exact same underlying real-world component or fact, even if their ids, titles, or descriptions differ slightly.
+
+Definitions:
+- Only compare features within the same category: type + subtype must match for two features to be considered duplicates.
+- If ambiguous, treat as NOT duplicates.
+- Same technology family ≠ duplicates. Only truly interchangeable features are duplicates.
+- Two features are duplicates only if an operator would consider them interchangeable: knowing one tells you everything knowing the other would.
+
+Burden of proof for each cluster:
+- You must be able to state in one sentence what single real-world thing all members refer to.
+- A valid identity statement names a specific component or process, not a category or domain.
+- If you cannot write the one-sentence identity, the features are NOT duplicates.
+
+Method:
+1. Read the full list of unique features.
+2. Apply the burden-of-proof test before finalising each cluster.
+3. Return K = the number of semantic clusters you formed. K must be <= N (provided in the input as unique_by_id).

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_user_prompt.text
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/src/evaluators/feature_duplication/semantic_uniqueness_user_prompt.text
@@ -1,0 +1,11 @@
+Evaluate the following feature set for semantic uniqueness:
+
+**Stream name**: {{{stream_name}}}
+
+**Totals**:
+{{{totals}}}
+
+**Unique features by id**:
+{{{unique_features_by_id}}}
+
+Please analyze the features and call the `analyze` tool with your findings.

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@kbn/tsconfig-base/tsconfig.json",
   "compilerOptions": {
     "outDir": "target/types",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "@kbn/ambient-common-types"]
   },
   "include": ["**/*.ts"],
   "exclude": ["target/**/*"],
@@ -24,6 +24,8 @@
     "@kbn/core",
     "@kbn/dissect-heuristics",
     "@kbn/inference-common",
+    "@kbn/inference-prompt-utils",
+    "@kbn/zod",
     "@kbn/es-snapshot-loader",
     "@kbn/es-errors"
   ]


### PR DESCRIPTION
Closes #255869

## Summary

Converts the two LLM evaluators in feature duplication evals (`createSemanticUniquenessEvaluator` and `createIdConsistencyEvaluator`) from `inferenceClient.output()` with inline system prompts to the `createPrompt` + `executeUntilValid` pattern used by `@kbn/evals`. System prompts are extracted into `.text` mustache template files, and tool schemas are preserved as prompt version tool definitions. The CODE evaluator (`featureDuplicationEvaluator`) is unchanged. All evaluator names, signatures, and return shapes are preserved.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

No significant risks. This is a structural refactor of evaluator internals — the evaluator contracts (names, signatures, return shapes) are unchanged. The LLM prompts are semantically identical, just moved from inline strings to versioned mustache templates.

---
🤖