### PR TITLE
feat(streams): introduce SignificantEventsDiscovery workflow client

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -276,26 +276,6 @@ export type { IdentifyFeaturesResult, IterationResult } from './src/api/features
 export { tokenCountSchema, iterationResultSchema } from './src/api/features';
 
 export {
-  type GenerateInsightsResult,
-  type Insight,
-  type InsightCore,
-  type InsightEvidence,
-  type InsightImpactLevel,
-  type InsightImpactLevelNumeric,
-  type InsightUserEvaluation,
-  type InsightMeta,
-  type SaveInsightBody,
-  insightSchema,
-  insightCoreSchema,
-  insightMetaSchema,
-  insightEvidenceSchema,
-  insightImpactLevelSchema,
-  insightImpactLevelNumericSchema,
-  insightUserEvaluationSchema,
-  INSIGHT_IMPACT_LEVEL_MAP,
-  getImpactLevel,
-} from './src/insights';
-export {
   SIG_EVENT_STATUS_OPTIONS,
   SIG_EVENT_IMPACT_OPTIONS,
   detectionSchema,
@@ -313,11 +293,11 @@ export type {
   StreamsKIsOnboardingResult,
   StreamsKIsOnboardingFeaturesResult,
   StreamsKIsOnboardingQueriesResult,
-  StreamsKIsOnboardingStatusResult,
+  WorkflowStatusResult,
 } from './src/onboarding';
 export {
   StreamsKIsOnboardingStep,
-  StreamsKIsOnboardingStatus,
+  WorkflowStatus,
   STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES,
 } from './src/onboarding';
 export { streamsOasDefinitions } from './src/oas_definitions';

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/onboarding/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/onboarding/index.ts
@@ -35,7 +35,7 @@ export enum StreamsKIsOnboardingStep {
   QueriesGeneration = 'queries_generation',
 }
 
-export enum StreamsKIsOnboardingStatus {
+export enum WorkflowStatus {
   NotStarted = 'not_started',
   InProgress = 'in_progress',
   /** Client-only optimistic state; the server never returns this value. */
@@ -45,17 +45,19 @@ export enum StreamsKIsOnboardingStatus {
   Completed = 'completed',
 }
 
-export type StreamsKIsOnboardingStatusResult =
+export type WorkflowStatusResult =
   | {
       status:
-        | StreamsKIsOnboardingStatus.NotStarted
-        | StreamsKIsOnboardingStatus.InProgress
-        | StreamsKIsOnboardingStatus.BeingCanceled
-        | StreamsKIsOnboardingStatus.Canceled;
+        | WorkflowStatus.NotStarted
+        | WorkflowStatus.InProgress
+        | WorkflowStatus.BeingCanceled
+        | WorkflowStatus.Canceled;
     }
-  | { status: StreamsKIsOnboardingStatus.Failed; error: string }
-  | ({ status: StreamsKIsOnboardingStatus.Completed } & StreamsKIsOnboardingResult);
+  | { status: WorkflowStatus.Failed; error: string }
+  | ({ status: WorkflowStatus.Completed } & StreamsKIsOnboardingResult);
 
 /** Statuses that indicate the onboarding pipeline is still active (running or pending cancel). */
-export const STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES: ReadonlySet<StreamsKIsOnboardingStatus> =
-  new Set([StreamsKIsOnboardingStatus.InProgress, StreamsKIsOnboardingStatus.BeingCanceled]);
+export const STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES: ReadonlySet<WorkflowStatus> = new Set([
+  WorkflowStatus.InProgress,
+  WorkflowStatus.BeingCanceled,
+]);

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_cancel/handler.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_cancel/handler.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { httpServerMock } from '@kbn/core/server/mocks';
-import { StreamsKIsOnboardingStatus } from '@kbn/streams-schema';
+import { WorkflowStatus } from '@kbn/streams-schema';
 import { ExecutionStatus } from '@kbn/workflows';
 import { StreamsKIsOnboardingClient } from '../../../lib/workflows/onboarding_workflow_client';
 import { cancelKiIdentificationToolHandler } from './handler';
@@ -38,7 +38,7 @@ describe('cancelKiIdentificationToolHandler', () => {
     expect(result).toEqual({
       stream_name: 'logs.nginx',
       execution_id: 'exec-1',
-      status: StreamsKIsOnboardingStatus.Canceled,
+      status: WorkflowStatus.Canceled,
     });
   });
 
@@ -62,7 +62,7 @@ describe('cancelKiIdentificationToolHandler', () => {
     expect(result).toEqual({
       stream_name: 'logs.nginx',
       execution_id: null,
-      status: StreamsKIsOnboardingStatus.Canceled,
+      status: WorkflowStatus.Canceled,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_cancel/handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_cancel/handler.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
-import { StreamsKIsOnboardingStatus } from '@kbn/streams-schema';
+import { WorkflowStatus } from '@kbn/streams-schema';
 import type { StreamsKIsOnboardingClient } from '../../../lib/workflows/onboarding_workflow_client';
 
 interface CancelKiIdentificationHandlerParams {
@@ -18,7 +18,7 @@ interface CancelKiIdentificationHandlerParams {
 interface CancelKiIdentificationHandlerResult {
   stream_name: string;
   execution_id: string | null;
-  status: StreamsKIsOnboardingStatus.Canceled;
+  status: WorkflowStatus.Canceled;
 }
 
 export async function cancelKiIdentificationToolHandler({
@@ -31,6 +31,6 @@ export async function cancelKiIdentificationToolHandler({
   return {
     stream_name: streamName,
     execution_id: executionId,
-    status: StreamsKIsOnboardingStatus.Canceled,
+    status: WorkflowStatus.Canceled,
   };
 }

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_cancel/tool.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_cancel/tool.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { StreamsKIsOnboardingStatus } from '@kbn/streams-schema';
+import { WorkflowStatus } from '@kbn/streams-schema';
 import { ExecutionStatus } from '@kbn/workflows';
 import { StreamsKIsOnboardingClient } from '../../../lib/workflows/onboarding_workflow_client';
 import { createKiIdentificationCancelTool } from './tool';
@@ -46,7 +46,7 @@ describe('createKiIdentificationCancelTool', () => {
       expect(result.results[0].data).toEqual({
         stream_name: 'logs.nginx',
         execution_id: 'exec-1',
-        status: StreamsKIsOnboardingStatus.Canceled,
+        status: WorkflowStatus.Canceled,
       });
     }
   });

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_status/handler.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_status/handler.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { StreamsKIsOnboardingStatus } from '@kbn/streams-schema';
+import { WorkflowStatus } from '@kbn/streams-schema';
 import { StreamsKIsOnboardingClient } from '../../../lib/workflows/onboarding_workflow_client';
 import { getKiIdentificationStatusToolHandler } from './handler';
 
@@ -26,7 +26,7 @@ describe('getKiIdentificationStatusToolHandler', () => {
     expect(result).toEqual({
       stream_name: 'logs.nginx',
       execution_id: null,
-      status: StreamsKIsOnboardingStatus.NotStarted,
+      status: WorkflowStatus.NotStarted,
     });
   });
 });

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_status/tool.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/tools/ki_identification_status/tool.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { StreamsKIsOnboardingStatus } from '@kbn/streams-schema';
+import { WorkflowStatus } from '@kbn/streams-schema';
 import { ExecutionStatus } from '@kbn/workflows';
 import { StreamsKIsOnboardingClient } from '../../../lib/workflows/onboarding_workflow_client';
 import { createKiIdentificationStatusTool } from './tool';
@@ -59,7 +59,7 @@ describe('createKiIdentificationStatusTool', () => {
       expect(result.results[0].data).toEqual(
         expect.objectContaining({
           stream_name: 'logs.nginx',
-          status: StreamsKIsOnboardingStatus.Completed,
+          status: WorkflowStatus.Completed,
         })
       );
     }

--- a/x-pack/platform/plugins/shared/streams/server/lib/workflows/create_workflow_clients.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/workflows/create_workflow_clients.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import { StreamsKIsOnboardingClient } from './onboarding_workflow_client';
+import { SignificantEventsDiscoveryClient } from './significant_events_discovery_client';
+
+export interface WorkflowClients {
+  streamsKIsOnboardingClient: StreamsKIsOnboardingClient | undefined;
+  SignificantEventsDiscoveryClient: SignificantEventsDiscoveryClient | undefined;
+}
+export const createWorkflowClients = (
+  managementApi: WorkflowsServerPluginSetup['management'] | undefined
+): WorkflowClients => {
+  if (!managementApi) {
+    return { streamsKIsOnboardingClient: undefined, SignificantEventsDiscoveryClient: undefined };
+  }
+
+  return {
+    streamsKIsOnboardingClient: new StreamsKIsOnboardingClient({ managementApi }),
+    SignificantEventsDiscoveryClient: new SignificantEventsDiscoveryClient({ managementApi }),
+  };
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/workflows/onboarding_workflow_client.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/workflows/onboarding_workflow_client.test.ts
@@ -7,7 +7,7 @@
 
 import { parse } from 'yaml';
 import { httpServerMock } from '@kbn/core/server/mocks';
-import { StreamsKIsOnboardingStatus } from '@kbn/streams-schema';
+import { WorkflowStatus } from '@kbn/streams-schema';
 import { ExecutionStatus } from '@kbn/workflows';
 import {
   getManagedWorkflowDefinition,
@@ -18,7 +18,6 @@ import {
   buildConcurrencyKey,
   parseStreamNameFromConcurrencyKey,
 } from './onboarding_workflow_client';
-
 const createMockManagementApi = (overrides: Record<string, jest.Mock> = {}) => ({
   getWorkflow: jest.fn().mockResolvedValue({
     id: STREAMS_KI_ONBOARDING_WORKFLOW_ID,
@@ -151,7 +150,7 @@ describe('StreamsKIsOnboardingClient', () => {
 
       const result = await client.getStatus({ streamName: 'logs.nginx' });
 
-      expect(result).toEqual({ status: StreamsKIsOnboardingStatus.NotStarted, executionId: null });
+      expect(result).toEqual({ status: WorkflowStatus.NotStarted, executionId: null });
     });
 
     it('returns InProgress for a running execution', async () => {
@@ -164,7 +163,7 @@ describe('StreamsKIsOnboardingClient', () => {
       const result = await client.getStatus({ streamName: 'logs.nginx' });
 
       expect(result).toEqual({
-        status: StreamsKIsOnboardingStatus.InProgress,
+        status: WorkflowStatus.InProgress,
         executionId: 'exec-1',
       });
     });
@@ -193,7 +192,7 @@ describe('StreamsKIsOnboardingClient', () => {
       const result = await client.getStatus({ streamName: 'logs.nginx' });
 
       expect(result).toEqual({
-        status: StreamsKIsOnboardingStatus.Completed,
+        status: WorkflowStatus.Completed,
         executionId: 'exec-1',
         features: {
           skipped: false,
@@ -221,7 +220,7 @@ describe('StreamsKIsOnboardingClient', () => {
       const result = await client.getStatus({ streamName: 'logs.nginx' });
 
       expect(result).toEqual({
-        status: StreamsKIsOnboardingStatus.Completed,
+        status: WorkflowStatus.Completed,
         executionId: 'exec-1',
         features: {
           skipped: false,
@@ -254,7 +253,7 @@ describe('StreamsKIsOnboardingClient', () => {
       const result = await client.getStatus({ streamName: 'logs.nginx' });
 
       expect(result).toEqual({
-        status: StreamsKIsOnboardingStatus.Failed,
+        status: WorkflowStatus.Failed,
         executionId: 'exec-1',
         error: 'something broke',
       });
@@ -270,7 +269,7 @@ describe('StreamsKIsOnboardingClient', () => {
       const result = await client.getStatus({ streamName: 'logs.nginx' });
 
       expect(result).toEqual({
-        status: StreamsKIsOnboardingStatus.Failed,
+        status: WorkflowStatus.Failed,
         executionId: 'exec-1',
         error: 'Onboarding workflow timed out',
       });
@@ -286,7 +285,7 @@ describe('StreamsKIsOnboardingClient', () => {
       const result = await client.getStatus({ streamName: 'logs.nginx' });
 
       expect(result).toEqual({
-        status: StreamsKIsOnboardingStatus.Canceled,
+        status: WorkflowStatus.Canceled,
         executionId: 'exec-1',
       });
     });

--- a/x-pack/platform/plugins/shared/streams/server/lib/workflows/onboarding_workflow_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/workflows/onboarding_workflow_client.ts
@@ -6,21 +6,21 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
-import { ExecutionStatus, NonTerminalExecutionStatuses, isTerminalStatus } from '@kbn/workflows';
+import { ExecutionStatus, NonTerminalExecutionStatuses } from '@kbn/workflows';
 import type { WorkflowExecutionListItemDto } from '@kbn/workflows';
 import { STREAMS_KI_ONBOARDING_WORKFLOW_ID } from '@kbn/workflows/managed';
-import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
-import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
 import type { ChatCompletionTokenCount } from '@kbn/inference-common';
 import {
-  StreamsKIsOnboardingStatus,
-  type StreamsKIsOnboardingStatusResult,
+  WorkflowStatus,
+  type WorkflowStatusResult,
   type StreamsKIsOnboardingFeaturesResult,
   type StreamsKIsOnboardingQueriesResult,
   type BaseFeature,
   type GeneratedSignificantEventQuery,
 } from '@kbn/streams-schema';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import { WorkflowExecutionService } from './workflow_execution_service';
 
 const EMPTY_TOKEN_COUNT: ChatCompletionTokenCount = { prompt: 0, completion: 0, total: 0 };
 
@@ -179,61 +179,32 @@ export const parseStreamNameFromConcurrencyKey = (key: string): string | null =>
   return key.slice(CONCURRENCY_KEY_PREFIX.length);
 };
 
-/** Maps a workflow engine execution status to the domain-level onboarding status. */
-const mapExecutionToOnboardingStatus = (
-  status: ExecutionStatus
-):
-  | StreamsKIsOnboardingStatus.InProgress
-  | StreamsKIsOnboardingStatus.Completed
-  | StreamsKIsOnboardingStatus.Failed
-  | StreamsKIsOnboardingStatus.Canceled => {
-  switch (status) {
-    case ExecutionStatus.PENDING:
-    case ExecutionStatus.RUNNING:
-    case ExecutionStatus.WAITING:
-    case ExecutionStatus.WAITING_FOR_INPUT:
-    case ExecutionStatus.WAITING_FOR_CHILD:
-      return StreamsKIsOnboardingStatus.InProgress;
-    case ExecutionStatus.COMPLETED:
-      return StreamsKIsOnboardingStatus.Completed;
-    case ExecutionStatus.FAILED:
-    case ExecutionStatus.TIMED_OUT:
-      return StreamsKIsOnboardingStatus.Failed;
-    case ExecutionStatus.CANCELLED:
-    case ExecutionStatus.SKIPPED:
-      return StreamsKIsOnboardingStatus.Canceled;
-    default:
-      const _exhaustiveCheck: never = status;
-      return _exhaustiveCheck;
-  }
-};
-
 /**
  * Converts a workflow execution (optionally enriched with `context.output`)
- * into the public {@link StreamsKIsOnboardingStatusResult} shape returned by the API.
+ * into the public {@link WorkflowStatusResult} shape returned by the API.
  * For completed executions the output is unpacked into summary counts;
  * for failures the error message is extracted.
  */
 const mapExecutionToStatusResult = (
   execution: WorkflowExecutionListItemDto
-): StreamsKIsOnboardingStatusResult => {
-  const onboardingStatus = mapExecutionToOnboardingStatus(execution.status);
+): WorkflowStatusResult => {
+  const onboardingStatus = WorkflowExecutionService.classifyExecutionStatus(execution.status);
 
-  if (onboardingStatus === StreamsKIsOnboardingStatus.Failed) {
+  if (onboardingStatus === WorkflowStatus.Failed) {
     const errorMessage =
       execution.status === ExecutionStatus.TIMED_OUT
         ? 'Onboarding workflow timed out'
         : execution.error?.message ?? 'Unknown error';
-    return { status: StreamsKIsOnboardingStatus.Failed, error: errorMessage };
+    return { status: WorkflowStatus.Failed, error: errorMessage };
   }
 
-  if (onboardingStatus === StreamsKIsOnboardingStatus.Completed) {
+  if (onboardingStatus === WorkflowStatus.Completed) {
     const ctx = (execution.context ?? {}) as {
       output?: Partial<OnboardingWorkflowOutputContext>;
     };
     const { features, queries } = parseWorkflowOutput(ctx.output ?? {});
     return {
-      status: StreamsKIsOnboardingStatus.Completed,
+      status: WorkflowStatus.Completed,
       features,
       queries,
     };
@@ -252,10 +223,10 @@ const MAX_STREAMS_PER_QUERY = 10000;
  * from the stream name, so at most one onboarding run is active per stream.
  */
 export class StreamsKIsOnboardingClient {
-  private readonly managementApi: WorkflowsServerPluginSetup['management'];
+  private readonly workflowExecutionService: WorkflowExecutionService;
 
   constructor({ managementApi }: { managementApi: WorkflowsServerPluginSetup['management'] }) {
-    this.managementApi = managementApi;
+    this.workflowExecutionService = new WorkflowExecutionService({ managementApi });
   }
 
   /**
@@ -272,21 +243,12 @@ export class StreamsKIsOnboardingClient {
     inputs: StreamsKIsOnboardingInputs;
     request: KibanaRequest;
   }): Promise<void> {
-    const workflow = await this.managementApi.getWorkflow(
-      STREAMS_KI_ONBOARDING_WORKFLOW_ID,
-      GLOBAL_WORKFLOW_SPACE_ID
-    );
-
-    if (!workflow || !workflow.definition) {
-      throw new Error(`Onboarding workflow ${STREAMS_KI_ONBOARDING_WORKFLOW_ID} not found`);
-    }
-
-    await this.managementApi.runWorkflow(
-      { ...workflow, definition: workflow.definition },
-      ONBOARDING_EXECUTIONS_SPACE_ID,
-      toWorkflowInputPayload(inputs),
-      request
-    );
+    await this.workflowExecutionService.execute({
+      workflowId: STREAMS_KI_ONBOARDING_WORKFLOW_ID,
+      executionSpaceId: ONBOARDING_EXECUTIONS_SPACE_ID,
+      inputs: toWorkflowInputPayload(inputs) as unknown as Record<string, unknown>,
+      request,
+    });
   }
 
   /**
@@ -300,8 +262,8 @@ export class StreamsKIsOnboardingClient {
     streamName,
   }: {
     streamName: string;
-  }): Promise<StreamsKIsOnboardingStatusResult & { executionId: string | null }> {
-    const { results } = await this.managementApi.getWorkflowExecutions(
+  }): Promise<WorkflowStatusResult & { executionId: string | null }> {
+    const { results } = await this.workflowExecutionService.getExecutions(
       {
         workflowId: STREAMS_KI_ONBOARDING_WORKFLOW_ID,
         concurrencyGroupKey: buildConcurrencyKey(streamName),
@@ -311,13 +273,13 @@ export class StreamsKIsOnboardingClient {
     );
 
     if (results.length === 0) {
-      return { status: StreamsKIsOnboardingStatus.NotStarted, executionId: null };
+      return { status: WorkflowStatus.NotStarted, executionId: null };
     }
 
     const execution = results[0];
 
     if (execution.status === ExecutionStatus.COMPLETED) {
-      const fullExecution = await this.managementApi.getWorkflowExecution(
+      const fullExecution = await this.workflowExecutionService.getExecution(
         execution.id,
         ONBOARDING_EXECUTIONS_SPACE_ID,
         { includeOutput: true }
@@ -351,25 +313,12 @@ export class StreamsKIsOnboardingClient {
     streamName: string;
     request: KibanaRequest;
   }): Promise<string | null> {
-    const { results } = await this.managementApi.getWorkflowExecutions(
-      {
-        workflowId: STREAMS_KI_ONBOARDING_WORKFLOW_ID,
-        concurrencyGroupKey: buildConcurrencyKey(streamName),
-        size: 1,
-      },
-      ONBOARDING_EXECUTIONS_SPACE_ID
-    );
-
-    if (results.length > 0 && !isTerminalStatus(results[0].status)) {
-      await this.managementApi.cancelWorkflowExecution(
-        results[0].id,
-        ONBOARDING_EXECUTIONS_SPACE_ID,
-        request
-      );
-      return results[0].id;
-    }
-
-    return null;
+    return this.workflowExecutionService.cancelLatest({
+      workflowId: STREAMS_KI_ONBOARDING_WORKFLOW_ID,
+      spaceId: ONBOARDING_EXECUTIONS_SPACE_ID,
+      request,
+      concurrencyGroupKey: buildConcurrencyKey(streamName),
+    });
   }
 
   /**
@@ -377,7 +326,7 @@ export class StreamsKIsOnboardingClient {
    * Used during teardown of the continuous KI extraction workflow.
    */
   async cancelAllRunning({ request }: { request: KibanaRequest }): Promise<void> {
-    const { results } = await this.managementApi.getWorkflowExecutions(
+    const { results } = await this.workflowExecutionService.getExecutions(
       {
         workflowId: STREAMS_KI_ONBOARDING_WORKFLOW_ID,
         statuses: [...NonTerminalExecutionStatuses],
@@ -392,7 +341,7 @@ export class StreamsKIsOnboardingClient {
 
     await Promise.all(
       results.map((result) =>
-        this.managementApi.cancelWorkflowExecution(
+        this.workflowExecutionService.cancelExecution(
           result.id,
           ONBOARDING_EXECUTIONS_SPACE_ID,
           request
@@ -412,7 +361,7 @@ export class StreamsKIsOnboardingClient {
    * completed run, breaking the "already running" classification.
    */
   async getRecentExecutions(): Promise<WorkflowExecutionListItemDto[]> {
-    const { results } = await this.managementApi.getWorkflowExecutions(
+    const { results } = await this.workflowExecutionService.getExecutions(
       {
         workflowId: STREAMS_KI_ONBOARDING_WORKFLOW_ID,
         size: MAX_STREAMS_PER_QUERY,

--- a/x-pack/platform/plugins/shared/streams/server/lib/workflows/significant_events_discovery_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/workflows/significant_events_discovery_client.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { SIGEVENTS_ORCHESTRATOR_WORKFLOW_ID } from '@kbn/workflows/managed';
+import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import { WorkflowStatus } from '@kbn/streams-schema';
+import type { WorkflowExecutionListItemDto } from '@kbn/workflows';
+import { WorkflowExecutionService } from './workflow_execution_service';
+
+export interface SignificantEventsDiscoveryRunParams {
+  request: KibanaRequest;
+  spaceId: string;
+  triggeredBy: 'manual' | 'scheduled';
+}
+
+export interface SignificantEventsDiscoveryStatusResult {
+  status:
+    | WorkflowStatus.NotStarted
+    | WorkflowStatus.InProgress
+    | WorkflowStatus.Completed
+    | WorkflowStatus.Failed
+    | WorkflowStatus.Canceled;
+  executionId: string | null;
+  error?: string;
+}
+
+/** Maps a workflow execution to the {@link SignificantEventsDiscoveryStatusResult} shape returned by the API. */
+const mapExecutionToStatusResult = (
+  execution: WorkflowExecutionListItemDto
+): Omit<SignificantEventsDiscoveryStatusResult, 'executionId'> & { executionId: string } => {
+  const status = WorkflowExecutionService.classifyExecutionStatus(execution.status);
+
+  if (status === WorkflowStatus.Failed) {
+    return {
+      status: WorkflowStatus.Failed,
+      executionId: execution.id,
+      error: execution.error?.message ?? 'Unknown error',
+    };
+  }
+
+  return { status, executionId: execution.id };
+};
+
+export class SignificantEventsDiscoveryClient {
+  private readonly workflowExecutionService: WorkflowExecutionService;
+
+  constructor({ managementApi }: { managementApi: WorkflowsServerPluginSetup['management'] }) {
+    this.workflowExecutionService = new WorkflowExecutionService({ managementApi });
+  }
+
+  async run({
+    request,
+    spaceId,
+    triggeredBy,
+  }: SignificantEventsDiscoveryRunParams): Promise<{ executionId: string }> {
+    const executionId = await this.workflowExecutionService.execute({
+      workflowId: SIGEVENTS_ORCHESTRATOR_WORKFLOW_ID,
+      executionSpaceId: spaceId,
+      inputs: { triggeredBy },
+      request,
+    });
+    return { executionId };
+  }
+
+  async cancel({
+    request,
+    spaceId,
+  }: {
+    request: KibanaRequest;
+    spaceId: string;
+  }): Promise<string | null> {
+    return this.workflowExecutionService.cancelLatest({
+      workflowId: SIGEVENTS_ORCHESTRATOR_WORKFLOW_ID,
+      spaceId,
+      request,
+    });
+  }
+
+  async getStatus({
+    spaceId,
+  }: {
+    spaceId: string;
+  }): Promise<SignificantEventsDiscoveryStatusResult> {
+    const { results } = await this.workflowExecutionService.getExecutions(
+      { workflowId: SIGEVENTS_ORCHESTRATOR_WORKFLOW_ID, size: 1 },
+      spaceId
+    );
+
+    if (results.length === 0) {
+      return { status: WorkflowStatus.NotStarted, executionId: null };
+    }
+
+    return mapExecutionToStatusResult(results[0]);
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/workflows/workflow_execution_service.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/workflows/workflow_execution_service.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { ExecutionStatus, isTerminalStatus } from '@kbn/workflows';
+import { GLOBAL_WORKFLOW_SPACE_ID } from '@kbn/workflows/server';
+import type {
+  WorkflowsManagementApi,
+  WorkflowsServerPluginSetup,
+} from '@kbn/workflows-management-plugin/server';
+import { WorkflowStatus } from '@kbn/streams-schema';
+
+export class WorkflowExecutionService {
+  private readonly managementApi: WorkflowsServerPluginSetup['management'];
+
+  constructor({ managementApi }: { managementApi: WorkflowsServerPluginSetup['management'] }) {
+    this.managementApi = managementApi;
+  }
+
+  /**
+   * Maps a raw workflow engine `ExecutionStatus` to the shared domain status.
+   * Does not cover `NotStarted` (no execution exists) or `BeingCanceled` (client-only optimistic state).
+   */
+  static classifyExecutionStatus(
+    status: ExecutionStatus
+  ):
+    | WorkflowStatus.InProgress
+    | WorkflowStatus.Completed
+    | WorkflowStatus.Failed
+    | WorkflowStatus.Canceled {
+    switch (status) {
+      case ExecutionStatus.PENDING:
+      case ExecutionStatus.RUNNING:
+      case ExecutionStatus.WAITING:
+      case ExecutionStatus.WAITING_FOR_INPUT:
+      case ExecutionStatus.WAITING_FOR_CHILD:
+        return WorkflowStatus.InProgress;
+      case ExecutionStatus.COMPLETED:
+        return WorkflowStatus.Completed;
+      case ExecutionStatus.FAILED:
+      case ExecutionStatus.TIMED_OUT:
+        return WorkflowStatus.Failed;
+      case ExecutionStatus.CANCELLED:
+      case ExecutionStatus.SKIPPED:
+        return WorkflowStatus.Canceled;
+      default:
+        const _exhaustiveCheck: never = status;
+        return _exhaustiveCheck;
+    }
+  }
+
+  async execute({
+    workflowId,
+    executionSpaceId,
+    inputs,
+    request,
+  }: {
+    workflowId: string;
+    executionSpaceId: string;
+    inputs: Record<string, unknown>;
+    request: KibanaRequest;
+  }): Promise<string> {
+    const workflow = await this.managementApi.getWorkflow(workflowId, GLOBAL_WORKFLOW_SPACE_ID);
+
+    if (!workflow || !workflow.definition) {
+      throw new Error(`Workflow ${workflowId} not found`);
+    }
+
+    return this.managementApi.runWorkflow(
+      { ...workflow, definition: workflow.definition },
+      executionSpaceId,
+      inputs,
+      request
+    );
+  }
+
+  async cancelLatest({
+    workflowId,
+    spaceId,
+    request,
+    concurrencyGroupKey,
+  }: {
+    workflowId: string;
+    spaceId: string;
+    request: KibanaRequest;
+    concurrencyGroupKey?: string;
+  }): Promise<string | null> {
+    const { results } = await this.managementApi.getWorkflowExecutions(
+      {
+        workflowId,
+        ...(concurrencyGroupKey !== undefined && { concurrencyGroupKey }),
+        size: 1,
+      },
+      spaceId
+    );
+
+    if (results.length > 0 && !isTerminalStatus(results[0].status)) {
+      await this.managementApi.cancelWorkflowExecution(results[0].id, spaceId, request);
+      return results[0].id;
+    }
+
+    return null;
+  }
+
+  async getExecutions(
+    params: Parameters<WorkflowsManagementApi['getWorkflowExecutions']>[0],
+    spaceId: string
+  ) {
+    return this.managementApi.getWorkflowExecutions(params, spaceId);
+  }
+
+  async getExecution(
+    id: string,
+    spaceId: string,
+    options?: Parameters<WorkflowsManagementApi['getWorkflowExecution']>[2]
+  ) {
+    return this.managementApi.getWorkflowExecution(id, spaceId, options);
+  }
+
+  async cancelExecution(id: string, spaceId: string, request: KibanaRequest): Promise<void> {
+    return this.managementApi.cancelWorkflowExecution(id, spaceId, request);
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -85,6 +85,7 @@ import {
   type ContinuousKiExtractionWorkflowService,
 } from './lib/workflows/continuous_extraction_workflow';
 import { StreamsKIsOnboardingClient } from './lib/workflows/onboarding_workflow_client';
+import { createWorkflowClients } from './lib/workflows/create_workflow_clients';
 
 const STREAMS_MANAGED_WORKFLOW_OWNER = 'streams';
 
@@ -320,6 +321,8 @@ export class StreamsPlugin
       ? new StreamsKIsOnboardingClient({ managementApi: plugins.workflowsManagement.management })
       : undefined;
 
+    const workflowClients = createWorkflowClients(plugins.workflowsManagement?.management);
+
     if (plugins.agentBuilder) {
       registerStreamsAgentBuilder({
         agentBuilder: plugins.agentBuilder,
@@ -433,6 +436,11 @@ export class StreamsPlugin
         getScopedClients,
         continuousKiExtractionWorkflowService,
         streamsKIsOnboardingClient,
+        workflowClients,
+        getSpaceId: async (request: KibanaRequest) => {
+          const [, pluginsStart] = await core.getStartServices();
+          return pluginsStart.spaces?.spacesService.getSpaceId(request) ?? DEFAULT_SPACE_ID;
+        },
       },
       core,
       logger: this.logger,

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/significant_events/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/sig_events/significant_events/route.ts
@@ -12,6 +12,8 @@ import {
   type SignificantEventsQueriesGenerationTaskResult,
 } from '@kbn/streams-schema';
 import { z } from '@kbn/zod/v4';
+import type { SignificantEventsDiscoveryStatusResult } from '../../../../lib/workflows/significant_events_discovery_client';
+import { FeatureNotEnabledError } from '../../../../lib/streams/errors/feature_not_enabled_error';
 import { BUCKET_SIZE_PATTERN } from '../../../../lib/sig_events/helpers/fill_bucket_gaps';
 import { readSignificantEventsFromAlertsIndices } from '../../../../lib/sig_events/read_significant_events_from_alerts_indices';
 import { resolveAlertsSource } from '../../../utils/resolve_alerts_source';
@@ -229,8 +231,107 @@ const readAllSignificantEventsRoute = createServerRoute({
   },
 });
 
+const SignificantEventsDiscoveryExecuteRoute = createServerRoute({
+  endpoint: 'POST /internal/streams/significant_events/discovery/_execute',
+  params: z.object({
+    body: z.discriminatedUnion('action', [
+      z.object({ action: z.literal('trigger') }),
+      z.object({ action: z.literal('cancel') }),
+    ]),
+  }),
+  options: {
+    access: 'internal',
+    summary: 'Manually trigger the Significant Events pipeline',
+    description:
+      'Executes the Significant Events orchestrator workflow for the current space. Runs detection, discovery, and triage in sequence.',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.manage],
+    },
+  },
+  handler: async ({
+    params,
+    request,
+    getScopedClients,
+    workflowClients,
+    getSpaceId,
+    server,
+    telemetry,
+  }): Promise<{ executionId: string | null }> => {
+    const { licensing, uiSettingsClient } = await getScopedClients({ request });
+
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
+    const { SignificantEventsDiscoveryClient } = workflowClients;
+
+    if (!SignificantEventsDiscoveryClient) {
+      throw new FeatureNotEnabledError(
+        'Significant events discovery requires the workflows feature to be enabled'
+      );
+    }
+
+    const spaceId = await getSpaceId(request);
+    const { body } = params;
+
+    if (body.action === 'trigger') {
+      const { executionId } = await SignificantEventsDiscoveryClient.run({
+        request,
+        spaceId,
+        triggeredBy: 'manual',
+      });
+      telemetry.trackSignificantEventsDiscoveryTriggered({
+        triggered_by: 'manual',
+        execution_id: executionId,
+        space_id: spaceId,
+      });
+      return { executionId };
+    }
+
+    const executionId = await SignificantEventsDiscoveryClient.cancel({ request, spaceId });
+    return { executionId };
+  },
+});
+
+const SignificantEventsDiscoveryStatusRoute = createServerRoute({
+  endpoint: 'GET /internal/streams/significant_events/discovery/_status',
+  params: z.object({}),
+  options: {
+    access: 'internal',
+    summary: 'Get the status of the Significant Events discovery pipeline',
+    description:
+      'Returns the status of the most recent Significant Events orchestrator workflow execution for the current space.',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: [STREAMS_API_PRIVILEGES.read],
+    },
+  },
+  handler: async ({
+    request,
+    getScopedClients,
+    workflowClients,
+    getSpaceId,
+    server,
+  }): Promise<SignificantEventsDiscoveryStatusResult> => {
+    const { licensing, uiSettingsClient } = await getScopedClients({ request });
+
+    await assertSignificantEventsAccess({ server, licensing, uiSettingsClient });
+
+    if (!workflowClients) {
+      throw new FeatureNotEnabledError(
+        'Significant events discovery requires the workflows feature to be enabled'
+      );
+    }
+
+    const spaceId = await getSpaceId(request);
+    return workflowClients.SignificantEventsDiscoveryClient.getStatus({ spaceId });
+  },
+});
+
 export const internalSignificantEventsRoutes = {
   ...significantEventsQueriesGenerationStatusRoute,
   ...significantEventsQueriesGenerationTaskRoute,
   ...readAllSignificantEventsRoute,
+  ...SignificantEventsDiscoveryExecuteRoute,
+  ...SignificantEventsDiscoveryStatusRoute,
 };

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/onboarding/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/onboarding/route.ts
@@ -8,8 +8,8 @@
 import { z } from '@kbn/zod/v4';
 import {
   StreamsKIsOnboardingStep,
-  StreamsKIsOnboardingStatus,
-  type StreamsKIsOnboardingStatusResult,
+  WorkflowStatus,
+  type WorkflowStatusResult,
 } from '@kbn/streams-schema';
 import { STREAMS_API_PRIVILEGES } from '../../../../../common/constants';
 import { createServerRoute } from '../../../create_server_route';
@@ -32,7 +32,7 @@ export const onboardingExecuteRoute = createServerRoute({
     access: 'internal',
     summary: 'Onboard stream',
     description:
-      'Generate features and queries for a stream, the data that is necessary for insights discovery.',
+      'Generate features and queries for a stream as part of the significant events discovery workflow.',
   },
   security: {
     authz: {
@@ -84,8 +84,9 @@ export const onboardingExecuteRoute = createServerRoute({
     request,
     getScopedClients,
     server,
-    streamsKIsOnboardingClient,
-  }): Promise<StreamsKIsOnboardingStatusResult> => {
+    workflowClients,
+  }): Promise<WorkflowStatusResult> => {
+    const { streamsKIsOnboardingClient } = workflowClients;
     if (!streamsKIsOnboardingClient) {
       throw new FeatureNotEnabledError('Workflows management is not available');
     }
@@ -117,7 +118,7 @@ export const onboardingExecuteRoute = createServerRoute({
 
       await streamsKIsOnboardingClient.run({ inputs, request });
 
-      return { status: StreamsKIsOnboardingStatus.InProgress };
+      return { status: WorkflowStatus.InProgress };
     }
 
     // action === 'cancel'
@@ -152,8 +153,9 @@ export const onboardingStatusRoute = createServerRoute({
     request,
     getScopedClients,
     server,
-    streamsKIsOnboardingClient,
-  }): Promise<StreamsKIsOnboardingStatusResult> => {
+    workflowClients,
+  }): Promise<WorkflowStatusResult> => {
+    const { streamsKIsOnboardingClient } = workflowClients;
     if (!streamsKIsOnboardingClient) {
       throw new FeatureNotEnabledError('Workflows management is not available');
     }

--- a/x-pack/platform/plugins/shared/streams/server/routes/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/types.ts
@@ -31,6 +31,7 @@ import type { InsightClient } from '../lib/sig_events/insights/client/insight_cl
 import type { StreamsSettingsStorageClient } from '../lib/streams/storage/streams_settings_storage_client';
 import type { ContinuousKiExtractionWorkflowService } from '../lib/workflows/continuous_extraction_workflow';
 import type { StreamsKIsOnboardingClient } from '../lib/workflows/onboarding_workflow_client';
+import type { WorkflowClients } from '../lib/workflows/create_workflow_clients';
 import type { SigEventsTuningConfig } from '../../common/sig_events_tuning_config';
 
 export type GetScopedClients = (params: {
@@ -67,6 +68,8 @@ export interface RouteDependencies {
   patternExtractionService: IPatternExtractionService;
   continuousKiExtractionWorkflowService?: ContinuousKiExtractionWorkflowService;
   streamsKIsOnboardingClient?: StreamsKIsOnboardingClient;
+  workflowClients?: WorkflowClients;
+  getSpaceId: (request: KibanaRequest) => Promise<string>;
 }
 
 export type StreamsRouteHandlerResources = RouteDependencies & DefaultRouteHandlerResources;

--- a/x-pack/platform/plugins/shared/streams/test/scout/.meta/api/standard.json
+++ b/x-pack/platform/plugins/shared/streams/test/scout/.meta/api/standard.json
@@ -1,5 +1,5 @@
 {
-  "sha1": "420b23fc1b24c0f94f4302a7120a0e80fa48d851",
+  "sha1": "a8d72250e8d37b3033122b5f48f1fde2c391e441",
   "tests": [
     {
       "id": "dc6084aa7695e8a-26220f9b20676c1",
@@ -13,8 +13,8 @@
       }
     },
     {
-      "id": "a940fbb08bf35e5-b0497b949dc6073",
-      "title": "Insights CRUD API should create a new insight",
+      "id": "b44f6c2216cb6bc-ea3faff2f10da6c",
+      "title": "Memory CRUD API smoke: create, read, search, categories, soft-delete, and restore by name",
       "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
@@ -23,14 +23,14 @@
         "@cloud-serverless-observability_complete"
       ],
       "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 65,
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/memory/memory_crud.spec.ts",
+        "line": 45,
         "column": 12
       }
     },
     {
-      "id": "a940fbb08bf35e5-4cf3f03dab9340c",
-      "title": "Insights CRUD API should get an insight by ID",
+      "id": "b44f6c2216cb6bc-597176718a618d6",
+      "title": "Memory CRUD API a freshly written page is immediately readable without polling",
       "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
@@ -39,14 +39,14 @@
         "@cloud-serverless-observability_complete"
       ],
       "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 90,
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/memory/memory_crud.spec.ts",
+        "line": 216,
         "column": 12
       }
     },
     {
-      "id": "a940fbb08bf35e5-566c7fade75040e",
-      "title": "Insights CRUD API should return 404 for non-existent insight",
+      "id": "b44f6c2216cb6bc-24f17689411c1be",
+      "title": "Memory CRUD API removing a category does not return the stale older version",
       "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
@@ -55,30 +55,14 @@
         "@cloud-serverless-observability_complete"
       ],
       "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 116,
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/memory/memory_crud.spec.ts",
+        "line": 305,
         "column": 12
       }
     },
     {
-      "id": "a940fbb08bf35e5-cf00fb204ed0373",
-      "title": "Insights CRUD API should list all insights",
-      "expectedStatus": "skipped",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 129,
-        "column": 13
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-50c0d497cbfa529",
-      "title": "Insights CRUD API should filter insights by impact",
+      "id": "b44f6c2216cb6bc-0f36a39d57a31b9",
+      "title": "Memory CRUD API search does not return a page whose latest version no longer matches the filter",
       "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
@@ -87,14 +71,14 @@
         "@cloud-serverless-observability_complete"
       ],
       "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 170,
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/memory/memory_crud.spec.ts",
+        "line": 379,
         "column": 12
       }
     },
     {
-      "id": "a940fbb08bf35e5-68edc56df260e0f",
-      "title": "Insights CRUD API should update an existing insight",
+      "id": "b44f6c2216cb6bc-695cc6450b8de2c",
+      "title": "Memory CRUD API search does not return a soft-deleted page even if its latest version matches the filter",
       "expectedStatus": "passed",
       "tags": [
         "@local-stateful-classic",
@@ -103,136 +87,8 @@
         "@cloud-serverless-observability_complete"
       ],
       "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 209,
-        "column": 12
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-29fe613a0f05ad5",
-      "title": "Insights CRUD API should delete an insight",
-      "expectedStatus": "passed",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 245,
-        "column": 12
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-7788fbe4dc6bdfd",
-      "title": "Insights CRUD API should return 404 when deleting non-existent insight",
-      "expectedStatus": "passed",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 278,
-        "column": 12
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-3c7873d8e863808",
-      "title": "Insights CRUD API should bulk create insights",
-      "expectedStatus": "skipped",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 294,
-        "column": 13
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-eafe0d356e0d196",
-      "title": "Insights CRUD API should bulk delete insights",
-      "expectedStatus": "passed",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 330,
-        "column": 12
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-92a60158012600a",
-      "title": "Insights CRUD API should handle mixed bulk operations",
-      "expectedStatus": "skipped",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 381,
-        "column": 13
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-e61787ff5cbb060",
-      "title": "Insights CRUD API should fail bulk operations with non-existent IDs",
-      "expectedStatus": "skipped",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 444,
-        "column": 13
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-beee0cf3c2cdf70",
-      "title": "Insights CRUD API should deny read-only user from creating insights",
-      "expectedStatus": "passed",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 465,
-        "column": 12
-      }
-    },
-    {
-      "id": "a940fbb08bf35e5-70c03112e8a6bff",
-      "title": "Insights CRUD API should deny read-only user from bulk operations",
-      "expectedStatus": "passed",
-      "tags": [
-        "@local-stateful-classic",
-        "@cloud-stateful-classic",
-        "@local-serverless-observability_complete",
-        "@cloud-serverless-observability_complete"
-      ],
-      "location": {
-        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/insights_crud.spec.ts",
-        "line": 482,
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/memory/memory_crud.spec.ts",
+        "line": 442,
         "column": 12
       }
     },
@@ -281,6 +137,48 @@
       "location": {
         "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/search_knowledge_indicators_tool.spec.ts",
         "line": 217,
+        "column": 12
+      }
+    },
+    {
+      "id": "94c80912f6246f4-094ac08f869a28e",
+      "title": "Significant Events discovery pipeline API POST _execute (trigger) returns an executionId",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/significant_event_discovery_run.spec.ts",
+        "line": 27,
+        "column": 12
+      }
+    },
+    {
+      "id": "94c80912f6246f4-b38b60bd6807012",
+      "title": "Significant Events discovery pipeline API GET _status returns a valid status after trigger",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/significant_event_discovery_run.spec.ts",
+        "line": 47,
+        "column": 12
+      }
+    },
+    {
+      "id": "94c80912f6246f4-8f29a28b4278864",
+      "title": "Significant Events discovery pipeline API POST _execute (cancel) returns executionId or null",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-stateful-classic",
+        "@cloud-stateful-classic"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/significant_event_discovery_run.spec.ts",
+        "line": 72,
         "column": 12
       }
     },

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/services/streams_api_service.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/services/streams_api_service.ts
@@ -10,11 +10,6 @@ import type { Condition, StreamlangDSL } from '@kbn/streamlang';
 import type { RoutingStatus, Streams } from '@kbn/streams-schema';
 import type { IngestStream, IngestUpsertRequest } from '@kbn/streams-schema';
 import {
-  getImpactLevel,
-  type Insight,
-  type InsightImpactLevel,
-} from '@kbn/streams-schema/src/insights';
-import {
   OBSERVABILITY_STREAMS_ENABLE_SIGNIFICANT_EVENTS,
   OBSERVABILITY_STREAMS_ENABLE_DRAFT_STREAMS,
   OBSERVABILITY_STREAMS_ENABLE_WIRED_STREAM_VIEWS,
@@ -24,22 +19,16 @@ import { measurePerformanceAsync } from '@kbn/scout/src/common';
 import { STREAMS_SIGNIFICANT_EVENTS_MEMORY_ENABLED_FLAG } from '../../../../common/feature_flags';
 import { COMMON_API_HEADERS } from '../fixtures/constants';
 
-export type { Insight };
-
-export interface InsightBulkIndexOp {
-  index: Insight;
-}
-
-export interface InsightBulkDeleteOp {
-  delete: { id: string };
-}
-
-export type InsightBulkOperation = InsightBulkIndexOp | InsightBulkDeleteOp;
-
 export interface StreamsTestApiService {
   enable: () => Promise<void>;
   disable: () => Promise<void>;
   isEnabled: () => Promise<boolean>;
+  runSignificantEventsDiscovery: () => Promise<{ executionId: string }>;
+  cancelSignificantEventsDiscovery: () => Promise<{ executionId: string | null }>;
+  getSignificantEventsDiscoveryStatus: () => Promise<{
+    status: string;
+    executionId: string | null;
+  }>;
   listStreams: () => Promise<{ streams: Streams.all.Definition[] }>;
   getStream: (streamName: string) => Promise<IngestStream.all.GetResponse>;
   createStream: (streamName: string, body: Streams.all.UpsertRequest) => Promise<void>;
@@ -87,15 +76,6 @@ export interface StreamsTestApiService {
   deleteEsqlView: (viewName: string) => Promise<void>;
   runEsql: (query: string) => Promise<{ columns: Array<{ name: string }>; values: unknown[][] }>;
   cleanupTestStreams: (prefix?: string) => Promise<void>;
-  // Insights API
-  listInsights: (filters?: {
-    impact?: InsightImpactLevel[];
-  }) => Promise<{ insights: Insight[]; total: number }>;
-  getInsight: (id: string) => Promise<{ insight: Insight }>;
-  saveInsight: (id: string, input: Insight) => Promise<{ insight: Insight }>;
-  deleteInsight: (id: string) => Promise<{ acknowledged: boolean }>;
-  bulkInsights: (operations: InsightBulkOperation[]) => Promise<{ acknowledged: boolean }>;
-  cleanupTestInsights: () => Promise<void>;
 }
 
 export function getStreamsTestApiService({
@@ -447,80 +427,48 @@ export function getStreamsTestApiService({
       });
     },
 
-    // Insights API methods
-    async listInsights(filters?: { impact?: InsightImpactLevel[] }) {
-      return measurePerformanceAsync(log, 'streamsTestApi.listInsights', async () => {
-        const query = new URLSearchParams();
-        if (filters?.impact?.length) query.set('impact', filters.impact.join(','));
-        const queryString = query.toString();
-        const path = `/internal/streams/_insights${queryString ? `?${queryString}` : ''}`;
-        const response = await kbnClient.request({
-          method: 'GET',
-          path,
-        });
-        return response.data as { insights: Insight[]; total: number };
-      });
-    },
-
-    async getInsight(id: string) {
-      return measurePerformanceAsync(log, 'streamsTestApi.getInsight', async () => {
-        const response = await kbnClient.request({
-          method: 'GET',
-          path: `/internal/streams/_insights/${id}`,
-        });
-        return response.data as { insight: Insight };
-      });
-    },
-
-    async saveInsight(id: string, input: Insight) {
-      return measurePerformanceAsync(log, 'streamsTestApi.saveInsight', async () => {
-        const body: Insight = {
-          ...input,
-          id,
-          generated_at: input.generated_at ?? new Date().toISOString(),
-          impact_level: input.impact_level ?? getImpactLevel(input.impact),
-        };
-        const response = await kbnClient.request({
-          method: 'PUT',
-          path: `/internal/streams/_insights/${id}`,
-          body,
-        });
-        return response.data as { insight: Insight };
-      });
-    },
-
-    async deleteInsight(id: string) {
-      return measurePerformanceAsync(log, 'streamsTestApi.deleteInsight', async () => {
-        const response = await kbnClient.request({
-          method: 'DELETE',
-          path: `/internal/streams/_insights/${id}`,
-        });
-        return response.data as { acknowledged: boolean };
-      });
-    },
-
-    async bulkInsights(operations: InsightBulkOperation[]) {
-      return measurePerformanceAsync(log, 'streamsTestApi.bulkInsights', async () => {
-        const response = await kbnClient.request({
-          method: 'POST',
-          path: '/internal/streams/_insights/_bulk',
-          body: { operations },
-        });
-        return response.data as { acknowledged: boolean };
-      });
-    },
-
-    async cleanupTestInsights() {
-      await measurePerformanceAsync(log, 'streamsTestApi.cleanupTestInsights', async () => {
-        try {
-          const { insights } = await this.listInsights();
-          if (insights.length > 0) {
-            await this.bulkInsights(insights.map((insight) => ({ delete: { id: insight.id } })));
-          }
-        } catch (error) {
-          log.debug(`Failed to cleanup insights: ${error}`);
+    async runSignificantEventsDiscovery() {
+      return measurePerformanceAsync(
+        log,
+        'streamsTestApi.runSignificantEventsDiscovery',
+        async () => {
+          const response = await kbnClient.request({
+            method: 'POST',
+            path: '/internal/streams/significant_events/discovery/_execute',
+            body: { action: 'trigger' },
+          });
+          return response.data as { executionId: string };
         }
-      });
+      );
+    },
+
+    async cancelSignificantEventsDiscovery() {
+      return measurePerformanceAsync(
+        log,
+        'streamsTestApi.cancelSignificantEventsDiscovery',
+        async () => {
+          const response = await kbnClient.request({
+            method: 'POST',
+            path: '/internal/streams/significant_events/discovery/_execute',
+            body: { action: 'cancel' },
+          });
+          return response.data as { executionId: string | null };
+        }
+      );
+    },
+
+    async getSignificantEventsDiscoveryStatus() {
+      return measurePerformanceAsync(
+        log,
+        'streamsTestApi.getSignificantEventsDiscoveryStatus',
+        async () => {
+          const response = await kbnClient.request({
+            method: 'GET',
+            path: '/internal/streams/significant_events/discovery/_status',
+          });
+          return response.data as { status: string; executionId: string | null };
+        }
+      );
     },
   };
 }

--- a/x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/significant_event_discovery_run.spec.ts
+++ b/x-pack/platform/plugins/shared/streams/test/scout/api/tests/sig_events/significant_event_discovery_run.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import { tags } from '@kbn/scout';
+import { streamsApiTest as apiTest } from '../../fixtures';
+import { PUBLIC_API_HEADERS } from '../../fixtures/constants';
+
+apiTest.describe(
+  'Significant Events discovery pipeline API',
+  { tag: [...tags.stateful.classic] },
+  () => {
+    apiTest.beforeAll(async ({ apiServices }) => {
+      await apiServices.streamsTest.enable();
+      await apiServices.streamsTest.enableSignificantEvents();
+    });
+
+    apiTest.afterAll(async ({ apiServices }) => {
+      await apiServices.streamsTest.disableSignificantEvents();
+      await apiServices.streamsTest.disable();
+    });
+
+    apiTest('POST _execute (trigger) returns an executionId', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+
+      const { statusCode, body } = await apiClient.post(
+        'internal/streams/significant_events/discovery/_execute',
+        {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          body: { action: 'trigger' },
+          responseType: 'json',
+        }
+      );
+
+      expect(statusCode).toBe(200);
+      expect(body.executionId).toBeDefined();
+      expect(typeof body.executionId).toBe('string');
+    });
+
+    apiTest('GET _status returns a valid status after trigger', async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asStreamsAdmin();
+
+      // Trigger a run first so status is not_started
+      await apiClient.post('internal/streams/significant_events/discovery/_execute', {
+        headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+        body: { action: 'trigger' },
+        responseType: 'json',
+      });
+
+      const { statusCode, body } = await apiClient.get(
+        'internal/streams/significant_events/discovery/_status',
+        {
+          headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+          responseType: 'json',
+        }
+      );
+
+      expect(statusCode).toBe(200);
+      expect(body.status).toBeDefined();
+      expect(['not_started', 'in_progress', 'completed', 'failed', 'canceled']).toContain(
+        body.status
+      );
+    });
+
+    apiTest(
+      'POST _execute (cancel) returns executionId or null',
+      async ({ apiClient, samlAuth }) => {
+        const { cookieHeader } = await samlAuth.asStreamsAdmin();
+
+        const { statusCode, body } = await apiClient.post(
+          'internal/streams/significant_events/discovery/_execute',
+          {
+            headers: { ...PUBLIC_API_HEADERS, ...cookieHeader },
+            body: { action: 'cancel' },
+            responseType: 'json',
+          }
+        );
+
+        expect(statusCode).toBe(200);
+        expect(body).toHaveProperty('executionId');
+        expect(body.executionId === null || typeof body.executionId === 'string').toBe(true);
+      }
+    );
+  }
+);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/shared/run_discovery_empty_prompt.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/shared/run_discovery_empty_prompt.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { ReactNode } from 'react';
+import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { AssetImage } from '../../../../asset_image';
+import {
+  DEFAULT_EMPTY_PROMPT_BODY,
+  DEFAULT_EMPTY_PROMPT_TITLE,
+  FIND_SIGNIFICANT_EVENTS_LABEL,
+} from './translations';
+
+const RUN_LOADING_LABEL = i18n.translate('xpack.streams.runDiscoveryEmptyPrompt.runLoadingLabel', {
+  defaultMessage: 'Running discovery...',
+});
+
+interface RunDiscoveryEmptyPromptProps {
+  title?: ReactNode;
+  body?: ReactNode;
+  onRun: () => void;
+  isRunning: boolean;
+  runTestSubj?: string;
+}
+
+export const RunDiscoveryEmptyPrompt = ({
+  title = DEFAULT_EMPTY_PROMPT_TITLE,
+  body = DEFAULT_EMPTY_PROMPT_BODY,
+  onRun,
+  isRunning,
+  runTestSubj,
+}: RunDiscoveryEmptyPromptProps) => (
+  <EuiEmptyPrompt
+    aria-live="polite"
+    titleSize="xs"
+    icon={<AssetImage type="significantEventsDiscovery" />}
+    title={<h2>{title}</h2>}
+    body={<p>{body}</p>}
+    actions={
+      <EuiButton
+        fill
+        iconType="sparkles"
+        onClick={() => onRun()}
+        isDisabled={isRunning}
+        isLoading={isRunning}
+        data-test-subj={runTestSubj}
+      >
+        {isRunning ? RUN_LOADING_LABEL : FIND_SIGNIFICANT_EVENTS_LABEL}
+      </EuiButton>
+    }
+  />
+);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/shared/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/shared/translations.ts
@@ -8,6 +8,42 @@
 import { i18n } from '@kbn/i18n';
 import type { Detection, Discovery } from '@kbn/streams-schema';
 
+export const FIND_SIGNIFICANT_EVENTS_LABEL = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.findSignificantEventsLabel',
+  {
+    defaultMessage: 'Find Significant Events',
+  }
+);
+
+export const DEFAULT_EMPTY_PROMPT_TITLE = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.defaultEmptyPromptTitle',
+  {
+    defaultMessage: 'No significant events detected in this time range',
+  }
+);
+
+export const DETECTIONS_EMPTY_PROMPT_TITLE = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.detectionsEmptyPromptTitle',
+  {
+    defaultMessage: 'No detections collected in this time range',
+  }
+);
+
+export const DISCOVERIES_EMPTY_PROMPT_TITLE = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.discoveriesEmptyPromptTitle',
+  {
+    defaultMessage: 'No discoveries in this time range',
+  }
+);
+
+export const DEFAULT_EMPTY_PROMPT_BODY = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.defaultEmptyPromptBody',
+  {
+    defaultMessage:
+      'Nothing was collected in the selected time range. Try a wider range, or find significant events to scan your alert data.',
+  }
+);
+
 export const GENERATE_FEATURES_BUTTON_LABEL = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.generateFeaturesButtonLabel',
   {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/find_significant_events_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/find_significant_events_button.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FIND_SIGNIFICANT_EVENTS_LABEL } from '../shared/translations';
+
+interface FindSignificantEventsButtonProps {
+  onRun: () => void;
+  onCancel: () => void;
+  isRunning: boolean;
+  isDisabled: boolean;
+}
+
+export const FindSignificantEventsButton = ({
+  onRun,
+  onCancel,
+  isRunning,
+  isDisabled,
+}: FindSignificantEventsButtonProps) => {
+  if (isRunning) {
+    return (
+      <EuiButton
+        iconType="stop"
+        onClick={onCancel}
+        color="warning"
+        data-test-subj="significant_events_cancel_discovery_button"
+      >
+        {i18n.translate('xpack.streams.significantEventsDiscovery.cancelLabel', {
+          defaultMessage: 'Cancel discovery',
+        })}
+      </EuiButton>
+    );
+  }
+
+  return (
+    <EuiButton
+      iconType="sparkles"
+      onClick={onRun}
+      isDisabled={isDisabled}
+      color="text"
+      data-test-subj="significant_events_discover_insights_button"
+    >
+      {FIND_SIGNIFICANT_EVENTS_LABEL}
+    </EuiButton>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/knowledge_indicators_column.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/knowledge_indicators_column.tsx
@@ -7,13 +7,13 @@
 
 import { EuiI18nNumber, EuiText } from '@elastic/eui';
 import { css } from '@emotion/css';
-import type { Streams, StreamsKIsOnboardingStatusResult } from '@kbn/streams-schema';
+import type { Streams, WorkflowStatusResult } from '@kbn/streams-schema';
 import React from 'react';
 import { useStreamFeatures } from '../../../../../hooks/sig_events/use_stream_features';
 
 interface KnowledgeIndicatorsColumnProps {
   stream: Streams.all.Definition;
-  streamOnboardingResult?: StreamsKIsOnboardingStatusResult;
+  streamOnboardingResult?: WorkflowStatusResult;
 }
 
 export function KnowledgeIndicatorsColumn({

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/queries_column.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/queries_column.tsx
@@ -7,7 +7,7 @@
 
 import { EuiI18nNumber, EuiText } from '@elastic/eui';
 import { css } from '@emotion/css';
-import type { StreamsKIsOnboardingStatusResult } from '@kbn/streams-schema';
+import type { WorkflowStatusResult } from '@kbn/streams-schema';
 import React from 'react';
 import { useFetchDiscoveryQueries } from '../../../../../hooks/sig_events/use_fetch_discovery_queries';
 
@@ -16,7 +16,7 @@ const ACTIVE_DRAFT_STATUS = ['active', 'draft'] as const;
 
 interface QueriesColumnProps {
   streamName: string;
-  streamOnboardingResult?: StreamsKIsOnboardingStatusResult;
+  streamOnboardingResult?: WorkflowStatusResult;
 }
 
 export function QueriesColumn({ streamName, streamOnboardingResult }: QueriesColumnProps) {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
@@ -6,36 +6,19 @@
  */
 
 import type { EuiSearchBarProps, Query } from '@elastic/eui';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSearchBar, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSearchBar, EuiText } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import { toMountPoint } from '@kbn/react-kibana-mount';
-import {
-  STREAMS_SIG_EVENTS_DISCOVERY_INFERENCE_FEATURE_ID,
-  TaskStatus,
-  STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES,
-} from '@kbn/streams-schema';
-import React, { useCallback, useEffect, useState } from 'react';
-import useAsyncFn from 'react-use/lib/useAsyncFn';
+import { STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES } from '@kbn/streams-schema';
+import React, { useCallback, useState } from 'react';
 import type { TableRow } from './utils';
-import { useInferenceFeatureConnectors } from '../../../../../hooks/sig_events/use_inference_feature_connectors';
 import { useAIFeatures } from '../../../../../hooks/use_ai_features';
-import { useKibana } from '../../../../../hooks/use_kibana';
-import { useInsightsDiscoveryApi } from '../../../../../hooks/sig_events/use_insights_discovery_api';
-import { useStreamsAppRouter } from '../../../../../hooks/use_streams_app_router';
-import { useTaskPolling } from '../../../../../hooks/use_task_polling';
-import { getFormattedError } from '../../../../../util/errors';
+import { useSignificantEventsDiscovery } from '../../../../../hooks/sig_events/use_significant_events_discovery';
 import { StreamsAppSearchBar } from '../../../../streams_app_search_bar';
 import { useKiGeneration } from '../knowledge_indicators_table/ki_generation_context';
 import { GenerateSplitButton } from '../shared/generate_split_button';
-import { InsightsSplitButton } from './insights_split_button';
-import {
-  getInsightsCompleteToastTitle,
-  INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON,
-  INSIGHTS_SCHEDULING_FAILURE_TITLE,
-  NO_INSIGHTS_TOAST_TITLE,
-  STREAMS_TABLE_SEARCH_ARIA_LABEL,
-} from './translations';
+import { FindSignificantEventsButton } from './find_significant_events_button';
+import { STREAMS_TABLE_SEARCH_ARIA_LABEL } from './translations';
 import { StreamsTreeTable } from './tree_table';
 
 const datePickerStyle = css`
@@ -47,14 +30,7 @@ const datePickerStyle = css`
 `;
 
 export function StreamsView() {
-  const {
-    core,
-    core: {
-      notifications: { toasts },
-    },
-  } = useKibana();
   const [searchQuery, setSearchQuery] = useState<Query | undefined>();
-  const [isWaitingForInsightsTask, setIsWaitingForInsightsTask] = useState(false);
 
   const {
     filteredStreams,
@@ -73,20 +49,13 @@ export function StreamsView() {
     bulkOnboardQueriesOnly,
   } = useKiGeneration();
 
-  const discoveryConnectors = useInferenceFeatureConnectors(
-    STREAMS_SIG_EVENTS_DISCOVERY_INFERENCE_FEATURE_ID
-  );
   const aiFeatures = useAIFeatures();
   const allConnectors = aiFeatures?.genAiConnectors?.connectors ?? [];
   const connectorError = aiFeatures?.genAiConnectors?.error;
   const isConnectorCatalogUnavailable =
     !allConnectors.length || !!aiFeatures?.genAiConnectors?.loading || !!connectorError;
 
-  const [discoveryConnectorOverride, setDiscoveryConnectorOverride] = useState<
-    string | undefined
-  >();
-  const displayDiscoveryConnectorId =
-    discoveryConnectorOverride ?? discoveryConnectors.resolvedConnectorId;
+  const { isRunning, handleRun, handleCancel } = useSignificantEventsDiscovery();
 
   const isStreamActionable = useCallback(
     (streamName: string) => {
@@ -98,84 +67,6 @@ export function StreamsView() {
   );
 
   const [selectedStreams, setSelectedStreams] = useState<TableRow[]>([]);
-  const router = useStreamsAppRouter();
-  const { scheduleInsightsDiscoveryTask, getInsightsDiscoveryTaskStatus } =
-    useInsightsDiscoveryApi();
-  const [{ value: insightsTask }, getInsightsTaskStatus] = useAsyncFn(
-    getInsightsDiscoveryTaskStatus
-  );
-  useTaskPolling({
-    task: insightsTask,
-    onPoll: getInsightsDiscoveryTaskStatus,
-    onRefresh: getInsightsTaskStatus,
-  });
-
-  const [{ loading: isSchedulingInsights }, scheduleInsightsTask] = useAsyncFn(async () => {
-    const streamNames =
-      selectedStreams.length > 0 ? selectedStreams.map((row) => row.stream.name) : undefined;
-    try {
-      await scheduleInsightsDiscoveryTask(streamNames, discoveryConnectorOverride);
-      setIsWaitingForInsightsTask(true);
-      await getInsightsTaskStatus();
-    } catch (error) {
-      toasts.addError(getFormattedError(error), {
-        title: INSIGHTS_SCHEDULING_FAILURE_TITLE,
-      });
-      throw error;
-    }
-  }, [
-    scheduleInsightsDiscoveryTask,
-    selectedStreams,
-    discoveryConnectorOverride,
-    toasts,
-    getInsightsTaskStatus,
-  ]);
-
-  useEffect(() => {
-    if (!isWaitingForInsightsTask || !insightsTask) return;
-    if (insightsTask.status !== TaskStatus.Completed && insightsTask.status !== TaskStatus.Failed) {
-      return;
-    }
-    setIsWaitingForInsightsTask(false);
-    if (insightsTask.status === TaskStatus.Failed) {
-      toasts.addError(getFormattedError(new Error(insightsTask.error)), {
-        title: INSIGHTS_SCHEDULING_FAILURE_TITLE,
-      });
-      return;
-    }
-    if (insightsTask.status === TaskStatus.Completed) {
-      const count = insightsTask.insights?.length ?? 0;
-      if (count === 0) {
-        toasts.addInfo({
-          title: NO_INSIGHTS_TOAST_TITLE,
-        });
-      } else {
-        const toast = toasts.addSuccess({
-          title: getInsightsCompleteToastTitle(count),
-          text: toMountPoint(
-            <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  size="s"
-                  data-test-subj="significant_events_view_insights_toast_button"
-                  onClick={() => {
-                    toasts.remove(toast);
-                    router.push('/_discovery/{tab}', {
-                      path: { tab: 'insights' },
-                      query: {},
-                    });
-                  }}
-                >
-                  {INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON}
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>,
-            core
-          ),
-        });
-      }
-    }
-  }, [isWaitingForInsightsTask, insightsTask, toasts, router, core]);
 
   const handleQueryChange: EuiSearchBarProps['onChange'] = ({ query }) => {
     if (query) setSearchQuery(query);
@@ -255,15 +146,11 @@ export function StreamsView() {
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <InsightsSplitButton
-              allConnectors={allConnectors}
-              connectorError={connectorError}
-              resolvedConnectorId={discoveryConnectors.resolvedConnectorId}
-              displayConnectorId={displayDiscoveryConnectorId}
-              onConnectorChange={setDiscoveryConnectorOverride}
-              onRun={scheduleInsightsTask}
-              isLoading={isSchedulingInsights || isWaitingForInsightsTask}
-              isDisabled={isConnectorCatalogUnavailable || discoveryConnectors.loading}
+            <FindSignificantEventsButton
+              onRun={handleRun}
+              onCancel={handleCancel}
+              isRunning={isRunning}
+              isDisabled={isConnectorCatalogUnavailable}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
@@ -100,46 +100,8 @@ export const ONBOARDING_FAILURE_TITLE = i18n.translate(
   }
 );
 
-export const DISCOVER_INSIGHTS_BUTTON_LABEL = i18n.translate(
-  'xpack.streams.significantEventsDiscovery.streamsView.discoverInsightsButtonLabel',
-  {
-    defaultMessage: 'Discover Insights',
-  }
-);
-
-export const INSIGHTS_SCHEDULING_FAILURE_TITLE = i18n.translate(
-  'xpack.streams.significantEventsDiscovery.streamsView.insightsSchedulingErrorTitle',
-  {
-    defaultMessage: 'Could not start Insights generation',
-  }
-);
-
-export function getInsightsCompleteToastTitle(count: number): string {
-  return i18n.translate(
-    'xpack.streams.significantEventsDiscovery.streamsView.insightsCompleteToastTitle',
-    {
-      defaultMessage: '{count} {count, plural, one {Insight} other {Insights}} found',
-      values: { count },
-    }
-  );
-}
-
-export const INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON = i18n.translate(
-  'xpack.streams.significantEventsDiscovery.streamsView.insightsCompleteToastViewButton',
-  {
-    defaultMessage: 'View Insights',
-  }
-);
-
-export const NO_INSIGHTS_TOAST_TITLE = i18n.translate(
-  'xpack.streams.significantEventsDiscovery.streamsView.noInsightsToastTitle',
-  {
-    defaultMessage: 'No Insights found',
-  }
-);
-
 export const DISCOVER_INSIGHTS_CONFIG_ARIA_LABEL = i18n.translate(
-  'xpack.streams.significantEventsDiscovery.streamsView.discoverInsightsConfigAriaLabel',
+  'xpack.streams.significantEventsDiscovery.streamsView.findSignificantEventsConfigAriaLabel',
   {
     defaultMessage: 'Configure discovery model',
   }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
@@ -24,9 +24,9 @@ import { i18n } from '@kbn/i18n';
 import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
 import {
   Streams,
-  StreamsKIsOnboardingStatus,
+  WorkflowStatus,
   STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES,
-  type StreamsKIsOnboardingStatusResult,
+  type WorkflowStatusResult,
 } from '@kbn/streams-schema';
 import React, { useState } from 'react';
 import { useStreamsAppRouter } from '../../../../../hooks/use_streams_app_router';
@@ -67,7 +67,7 @@ export function StreamsTreeTable({
   onStopOnboardingActionClick,
 }: {
   streams?: ListStreamDetail[];
-  streamOnboardingResultMap: Record<string, StreamsKIsOnboardingStatusResult>;
+  streamOnboardingResultMap: Record<string, WorkflowStatusResult>;
   loading?: boolean;
   searchQuery?: Query;
   selection: EuiTableSelectionType<TableRow>;
@@ -359,17 +359,17 @@ export function StreamsTreeTable({
                 }
 
                 switch (onboardingResult.status) {
-                  case StreamsKIsOnboardingStatus.InProgress:
-                  case StreamsKIsOnboardingStatus.BeingCanceled:
+                  case WorkflowStatus.InProgress:
+                  case WorkflowStatus.BeingCanceled:
                     return <EuiLoadingSpinner size="m" />;
-                  case StreamsKIsOnboardingStatus.NotStarted:
-                  case StreamsKIsOnboardingStatus.Canceled:
+                  case WorkflowStatus.NotStarted:
+                  case WorkflowStatus.Canceled:
                     return '-';
-                  case StreamsKIsOnboardingStatus.Completed:
+                  case WorkflowStatus.Completed:
                     return (
                       <EuiIcon type="checkCircleFill" color="success" size="m" aria-hidden={true} />
                     );
-                  case StreamsKIsOnboardingStatus.Failed:
+                  case WorkflowStatus.Failed:
                     return (
                       <EuiIconTip
                         size="m"
@@ -442,9 +442,7 @@ export function StreamsTreeTable({
                       <EuiButtonIcon
                         iconType="stop"
                         aria-label={STOP_STREAM_ONBOARDING_BUTTON_LABEL}
-                        disabled={
-                          onboardingResult.status === StreamsKIsOnboardingStatus.BeingCanceled
-                        }
+                        disabled={onboardingResult.status === WorkflowStatus.BeingCanceled}
                         onClick={() => onStopOnboardingActionClick(item.stream.name)}
                       />
                     </EuiToolTip>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/hooks/use_bulk_onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/hooks/use_bulk_onboarding.ts
@@ -6,10 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import {
-  StreamsKIsOnboardingStep,
-  type StreamsKIsOnboardingStatusResult,
-} from '@kbn/streams-schema';
+import { StreamsKIsOnboardingStep, type WorkflowStatusResult } from '@kbn/streams-schema';
 import pMap from 'p-map';
 import { useCallback, useState } from 'react';
 import type { ScheduleOnboardingOptions } from '../../../../hooks/use_onboarding_api';
@@ -19,10 +16,7 @@ import { getFormattedError } from '../../../../util/errors';
 import type { OnboardingConfig } from '../components/shared/types';
 import { useOnboardingStatusUpdateQueue } from './use_onboarding_status_update_queue';
 
-type StreamStatusUpdateCallback = (
-  streamName: string,
-  result: StreamsKIsOnboardingStatusResult
-) => void;
+type StreamStatusUpdateCallback = (streamName: string, result: WorkflowStatusResult) => void;
 
 interface UseBulkOnboardingOptions {
   onboardingConfig: OnboardingConfig;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/hooks/use_onboarding_status_update_queue.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/hooks/use_onboarding_status_update_queue.ts
@@ -7,7 +7,7 @@
 
 import {
   STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES,
-  type StreamsKIsOnboardingStatusResult,
+  type WorkflowStatusResult,
 } from '@kbn/streams-schema';
 import pMap from 'p-map';
 import { useCallback, useRef } from 'react';
@@ -15,7 +15,7 @@ import { useOnboardingApi } from '../../../../hooks/use_onboarding_api';
 
 type StreamOnboardingStatusUpdateCallback = (
   streamName: string,
-  status: StreamsKIsOnboardingStatusResult
+  status: WorkflowStatusResult
 ) => void;
 
 export function useOnboardingStatusUpdateQueue(

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/hooks/use_knowledge_indicators_onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/hooks/use_knowledge_indicators_onboarding.ts
@@ -9,9 +9,9 @@ import { useMutation, useQuery } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
 import { useCallback, useRef, useState } from 'react';
 import {
-  StreamsKIsOnboardingStatus,
+  WorkflowStatus,
   STREAMS_KIS_ONBOARDING_IN_PROGRESS_STATUSES,
-  type StreamsKIsOnboardingStatusResult,
+  type WorkflowStatusResult,
 } from '@kbn/streams-schema';
 import { useOnboardingApi } from '../../../../hooks/use_onboarding_api';
 import { getFormattedError } from '../../../../util/errors';
@@ -20,24 +20,14 @@ import { useKibana } from '../../../../hooks/use_kibana';
 interface Props {
   streamName: string;
   onComplete: (
-    completedState: Extract<
-      StreamsKIsOnboardingStatusResult,
-      { status: StreamsKIsOnboardingStatus.Completed }
-    >
+    completedState: Extract<WorkflowStatusResult, { status: WorkflowStatus.Completed }>
   ) => void;
-  onError: (
-    failedState: Extract<
-      StreamsKIsOnboardingStatusResult,
-      { status: StreamsKIsOnboardingStatus.Failed }
-    >
-  ) => void;
+  onError: (failedState: Extract<WorkflowStatusResult, { status: WorkflowStatus.Failed }>) => void;
 }
 
 export function useKnowledgeIndicatorsOnboarding({ streamName, onComplete, onError }: Props) {
-  const previousStatusRef = useRef<StreamsKIsOnboardingStatus | null>(null);
-  const [onboardingState, setOnboardingState] = useState<StreamsKIsOnboardingStatusResult | null>(
-    null
-  );
+  const previousStatusRef = useRef<WorkflowStatus | null>(null);
+  const [onboardingState, setOnboardingState] = useState<WorkflowStatusResult | null>(null);
 
   const {
     core: {
@@ -78,8 +68,8 @@ export function useKnowledgeIndicatorsOnboarding({ streamName, onComplete, onErr
     // To fix, the workflow engine should expose `cancelRequested` in
     // WorkflowExecutionDto so the server can return BeingCanceled.
     const shouldPreserveBeingCanceled =
-      previousStatusRef.current === StreamsKIsOnboardingStatus.BeingCanceled &&
-      state.status === StreamsKIsOnboardingStatus.InProgress;
+      previousStatusRef.current === WorkflowStatus.BeingCanceled &&
+      state.status === WorkflowStatus.InProgress;
 
     if (shouldPreserveBeingCanceled) {
       return state;
@@ -97,16 +87,16 @@ export function useKnowledgeIndicatorsOnboarding({ streamName, onComplete, onErr
      */
     if (
       previousStatusRef.current !== null &&
-      previousStatusRef.current !== StreamsKIsOnboardingStatus.Completed &&
-      state.status === StreamsKIsOnboardingStatus.Completed
+      previousStatusRef.current !== WorkflowStatus.Completed &&
+      state.status === WorkflowStatus.Completed
     ) {
       onComplete(state);
     }
 
     if (
       previousStatusRef.current !== null &&
-      previousStatusRef.current !== StreamsKIsOnboardingStatus.Failed &&
-      state.status === StreamsKIsOnboardingStatus.Failed
+      previousStatusRef.current !== WorkflowStatus.Failed &&
+      state.status === WorkflowStatus.Failed
     ) {
       onError(state);
     }
@@ -116,7 +106,7 @@ export function useKnowledgeIndicatorsOnboarding({ streamName, onComplete, onErr
     return state;
   }, [getOnboardingStatus, streamName, onComplete, onError]);
 
-  useQuery<StreamsKIsOnboardingStatusResult, Error>({
+  useQuery<WorkflowStatusResult, Error>({
     queryKey: ['knowledgeIndicatorsOnboardingStatus', streamName],
     queryFn: fetchStatus,
     enabled: !isScheduleLoading && !isCancelLoading,
@@ -124,13 +114,13 @@ export function useKnowledgeIndicatorsOnboarding({ streamName, onComplete, onErr
   });
 
   const scheduleKnowledgeIndicatorsOnboarding = useCallback(() => {
-    setOnboardingState({ status: StreamsKIsOnboardingStatus.InProgress });
+    setOnboardingState({ status: WorkflowStatus.InProgress });
     scheduleMutate(streamName);
   }, [scheduleMutate, streamName]);
 
   const cancelKnowledgeIndicatorsOnboarding = useCallback(() => {
-    setOnboardingState({ status: StreamsKIsOnboardingStatus.BeingCanceled });
-    previousStatusRef.current = StreamsKIsOnboardingStatus.BeingCanceled;
+    setOnboardingState({ status: WorkflowStatus.BeingCanceled });
+    previousStatusRef.current = WorkflowStatus.BeingCanceled;
     cancelMutate(streamName);
   }, [cancelMutate, streamName]);
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/index.tsx
@@ -20,11 +20,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { useDebouncedValue } from '@kbn/react-hooks';
 import { useQueryClient } from '@kbn/react-query';
-import {
-  type Streams,
-  StreamsKIsOnboardingStatus,
-  type StreamsKIsOnboardingStatusResult,
-} from '@kbn/streams-schema';
+import { type Streams, WorkflowStatus, type WorkflowStatusResult } from '@kbn/streams-schema';
 import type { KnowledgeIndicator } from '@kbn/streams-ai';
 import React, { useCallback, useMemo, useState } from 'react';
 import useInterval from 'react-use/lib/useInterval';
@@ -87,12 +83,7 @@ export function StreamDetailSignificantEventsView({ definition }: Props) {
     refetch,
   } = useFetchKnowledgeIndicators({ definition });
   const onKnowledgeIndicatorsOnboardingComplete = useCallback(
-    (
-      completedState: Extract<
-        StreamsKIsOnboardingStatusResult,
-        { status: StreamsKIsOnboardingStatus.Completed }
-      >
-    ) => {
+    (completedState: Extract<WorkflowStatusResult, { status: WorkflowStatus.Completed }>) => {
       const { features, queries } = completedState;
 
       const count = features.discovered.length + queries.persisted.length;
@@ -125,12 +116,7 @@ export function StreamDetailSignificantEventsView({ definition }: Props) {
   );
 
   const onKnowledgeIndicatorsOnboardingError = useCallback(
-    (
-      failedState: Extract<
-        StreamsKIsOnboardingStatusResult,
-        { status: StreamsKIsOnboardingStatus.Failed }
-      >
-    ) => {
+    (failedState: Extract<WorkflowStatusResult, { status: WorkflowStatus.Failed }>) => {
       toasts.addDanger({
         title: KNOWLEDGE_INDICATORS_ONBOARDING_FAILED_TOAST_TITLE,
         text: failedState.error,
@@ -152,9 +138,7 @@ export function StreamDetailSignificantEventsView({ definition }: Props) {
 
   useInterval(
     refetch,
-    knowledgeIndicatorsOnboardingState?.status === StreamsKIsOnboardingStatus.InProgress
-      ? 5000
-      : null
+    knowledgeIndicatorsOnboardingState?.status === WorkflowStatus.InProgress ? 5000 : null
   );
 
   const ruleKnowledgeIndicators = useMemo(
@@ -194,7 +178,7 @@ export function StreamDetailSignificantEventsView({ definition }: Props) {
     [typeFilterOptions]
   );
   const isKnowledgeIndicatorsGenerationCanceling =
-    knowledgeIndicatorsOnboardingState?.status === StreamsKIsOnboardingStatus.BeingCanceled;
+    knowledgeIndicatorsOnboardingState?.status === WorkflowStatus.BeingCanceled;
   const isGenerateButtonDisabled =
     knowledgeIndicatorsOnboardingState === null || isKnowledgeIndicatorsGenerationPending;
 

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_significant_events_discovery.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_significant_events_discovery.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQuery } from '@kbn/react-query';
+import { i18n } from '@kbn/i18n';
+import { WorkflowStatus } from '@kbn/streams-schema';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useKibana } from '../use_kibana';
+import { useSignificantEventsDiscoveryApi } from './use_significant_events_discovery_api';
+
+const POLL_INTERVAL_MS = 3000;
+
+const isTerminalStatus = (status: string) =>
+  status === WorkflowStatus.Completed ||
+  status === WorkflowStatus.Failed ||
+  status === WorkflowStatus.Canceled;
+
+export const useSignificantEventsDiscovery = () => {
+  const {
+    core: {
+      notifications: { toasts },
+    },
+  } = useKibana();
+
+  const {
+    triggerSignificantEventsDiscovery,
+    cancelSignificantEventsDiscovery,
+    getSignificantEventsDiscoveryStatus,
+  } = useSignificantEventsDiscoveryApi();
+
+  // Local status state — set optimistically on trigger AND updated from server polling.
+  // Mirrors the onboardingState pattern in useKnowledgeIndicatorsOnboarding.
+  const [SignificantEventsDiscoveryStatus, setSignificantEventsDiscoveryStatus] =
+    useState<WorkflowStatus | null>(null);
+
+  // Tracks the previous server-confirmed status for toast transition detection.
+  // null = no server status observed yet; used to suppress spurious toasts on mount.
+  const previousStatusRef = useRef<WorkflowStatus | null>(null);
+
+  const { mutate: triggerMutate } = useMutation({
+    mutationFn: triggerSignificantEventsDiscovery,
+    onError: (error: Error) => {
+      setSignificantEventsDiscoveryStatus(null);
+      toasts.addError(error, {
+        title: i18n.translate(
+          'xpack.streams.SignificantEventsDiscoveryWorkflow.triggerErrorTitle',
+          {
+            defaultMessage: 'Failed to start discovery pipeline',
+          }
+        ),
+      });
+    },
+  });
+
+  const { mutate: cancelMutate } = useMutation({
+    mutationFn: cancelSignificantEventsDiscovery,
+    onError: (error: Error) => {
+      toasts.addError(error, {
+        title: i18n.translate('xpack.streams.SignificantEventsDiscoveryWorkflow.cancelErrorTitle', {
+          defaultMessage: 'Failed to cancel discovery pipeline',
+        }),
+      });
+    },
+  });
+
+  // isRunning is declared before useQuery so it can drive refetchInterval.
+  // It includes the optimistic InProgress state set by handleRun so polling
+  // continues even before the server confirms the new execution.
+  const isRunning =
+    SignificantEventsDiscoveryStatus !== null &&
+    !isTerminalStatus(SignificantEventsDiscoveryStatus) &&
+    SignificantEventsDiscoveryStatus !== WorkflowStatus.NotStarted;
+
+  // queryFn is a pure fetch — no side effects. All subscribers share the same
+  // cached data via the query key. React Query deduplicates the network request
+  // across all mounted consumers; side effects are handled via useEffect below
+  // so every subscriber reacts correctly to the shared result.
+  const { data } = useQuery({
+    queryKey: ['significant_events_discovery_status'],
+    queryFn: getSignificantEventsDiscoveryStatus,
+    refetchInterval: isRunning ? POLL_INTERVAL_MS : false,
+  });
+
+  // Runs in every subscriber when the polled status changes. Updates local state
+  // and fires transition toasts when moving FROM a non-terminal TO a terminal status.
+  useEffect(() => {
+    const status = data?.status;
+    if (!status) return;
+
+    setSignificantEventsDiscoveryStatus(status);
+
+    const previous = previousStatusRef.current;
+    previousStatusRef.current = status;
+
+    // Only toast on transitions — never on first mount (previous === null).
+    if (previous === null || !isTerminalStatus(status) || isTerminalStatus(previous)) return;
+
+    if (status === WorkflowStatus.Completed) {
+      toasts.addSuccess({
+        title: i18n.translate('xpack.streams.SignificantEventsDiscoveryWorkflow.completedTitle', {
+          defaultMessage: 'Significant events discovery completed',
+        }),
+        text: i18n.translate('xpack.streams.SignificantEventsDiscoveryWorkflow.completedText', {
+          defaultMessage: 'New significant events are ready for analysis.',
+        }),
+      });
+    } else if (status === WorkflowStatus.Failed) {
+      toasts.addDanger({
+        title: i18n.translate('xpack.streams.SignificantEventsDiscoveryWorkflow.failedTitle', {
+          defaultMessage: 'Significant events discovery failed',
+        }),
+      });
+    } else {
+      toasts.addDanger({
+        title: i18n.translate('xpack.streams.SignificantEventsDiscoveryWorkflow.canceledTitle', {
+          defaultMessage: 'Significant events discovery canceled',
+        }),
+      });
+    }
+  }, [data?.status, toasts]);
+
+  const handleRun = useCallback(() => {
+    // Set optimistic InProgress so isRunning = true immediately (shows cancel button,
+    // starts polling). previousStatusRef stays as-is so the first server response
+    // that confirms InProgress → Completed correctly fires the completion toast.
+    previousStatusRef.current = WorkflowStatus.InProgress;
+    setSignificantEventsDiscoveryStatus(WorkflowStatus.InProgress);
+    triggerMutate();
+  }, [triggerMutate]);
+
+  const handleCancel = useCallback(() => {
+    cancelMutate();
+  }, [cancelMutate]);
+
+  return useMemo(
+    () => ({ isRunning, handleRun, handleCancel }),
+    [isRunning, handleRun, handleCancel]
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_significant_events_discovery_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_significant_events_discovery_api.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useAbortController } from '@kbn/react-hooks';
+import { useMemo } from 'react';
+import { useKibana } from '../use_kibana';
+
+export const useSignificantEventsDiscoveryApi = () => {
+  const {
+    dependencies: {
+      start: {
+        streams: { streamsRepositoryClient },
+      },
+    },
+  } = useKibana();
+
+  const { signal } = useAbortController();
+
+  return useMemo(
+    () => ({
+      triggerSignificantEventsDiscovery: () =>
+        streamsRepositoryClient.fetch(
+          'POST /internal/streams/significant_events/discovery/_execute',
+          {
+            params: { body: { action: 'trigger' as const } },
+            signal,
+          }
+        ),
+      cancelSignificantEventsDiscovery: () =>
+        streamsRepositoryClient.fetch(
+          'POST /internal/streams/significant_events/discovery/_execute',
+          {
+            params: { body: { action: 'cancel' as const } },
+            signal,
+          }
+        ),
+      getSignificantEventsDiscoveryStatus: () =>
+        streamsRepositoryClient.fetch(
+          'GET /internal/streams/significant_events/discovery/_status',
+          { params: {}, signal }
+        ),
+    }),
+    [signal, streamsRepositoryClient]
+  );
+};


### PR DESCRIPTION
## Summary

Introduces the infrastructure for the significant events discovery pipeline — a new workflow client, shared execution service, routes, and client-side hooks that allow users to trigger, cancel, and monitor the sig-events orchestrator workflow.

Part of elastic/nightshift-program#162

## Changes

### Server
- **`WorkflowExecutionService`** — shared abstraction wrapping the `workflowsManagement` API (`execute`, `cancelLatest`, `getExecutions`, `getExecution`, `cancelExecution`, `classifyExecutionStatus`)
- **`SignificantEventsDiscoveryClient`** — domain client for the sig-events orchestrator workflow (`run`, `cancel`, `getStatus`)
- **`createWorkflowClients`** — factory that instantiates both `StreamsKIsOnboardingClient` and `SignificantEventsDiscoveryClient` from a single `managementApi`
- **`StreamsKIsOnboardingClient`** refactored to delegate to `WorkflowExecutionService`
- **`WorkflowStatus`** enum renamed from `StreamsKIsOnboardingStatus` in `@kbn/streams-schema` — now shared across both clients
- New routes: `POST /internal/streams/significant_events/discovery/_execute` (trigger/cancel) and `GET /internal/streams/significant_events/discovery/_status`

### Client
- **`useSignificantEventsDiscovery`** — stateful lifecycle hook (useMutation + useQuery, optimistic state, toast transitions)
- **`useSignificantEventsDiscoveryApi`** — pure fetch layer (mirrors `useOnboardingApi`)
- **`FindSignificantEventsButton`** — toggles between "Find Significant Events" and "Cancel discovery" based on running state
- **`RunDiscoveryEmptyPrompt`** — empty state component for tabs with no data yet

## Test plan
- Scout API test: `significant_event_discovery_run.spec.ts`

Made with [Cursor](https://cursor.com)